### PR TITLE
Fix TripCard vertical spacing and capsize text overlap

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -49,7 +49,8 @@
       "Bash(pgrep:*)",
       "Bash(jj git remote:*)",
       "Bash(gh pr edit:*)",
-      "Bash(jj new:*)"
+      "Bash(jj new:*)",
+      "mcp__plugin_chrome-devtools-mcp_chrome-devtools__click"
     ]
   },
   "enabledPlugins": {

--- a/src/components/golfers/GolferCard.tsx
+++ b/src/components/golfers/GolferCard.tsx
@@ -29,7 +29,7 @@ export function GolferCard({ golfer, showHandicap = true, linkToDetail = true }:
           radius="full"
           color="amber"
         />
-        <Flex direction="column" gap="2" style={{ flex: 1 }}>
+        <Flex direction="column" gap="3" style={{ flex: 1 }}>
           <Text weight="medium">{golfer.name}</Text>
           {golfer.email && (
             <Text size="1" color="gray">

--- a/src/components/scoring/ScoreSummary.tsx
+++ b/src/components/scoring/ScoreSummary.tsx
@@ -26,7 +26,7 @@ export function ScoreSummary({
   return (
     <Card>
       <Grid columns="4" gap="3">
-        <Flex direction="column" align="center">
+        <Flex direction="column" align="center" gap="2">
           <Text size="1" color="gray">
             Gross
           </Text>
@@ -38,7 +38,7 @@ export function ScoreSummary({
           </Text>
         </Flex>
 
-        <Flex direction="column" align="center">
+        <Flex direction="column" align="center" gap="2">
           <Text size="1" color="gray">
             Net
           </Text>
@@ -50,7 +50,7 @@ export function ScoreSummary({
           </Text>
         </Flex>
 
-        <Flex direction="column" align="center">
+        <Flex direction="column" align="center" gap="2">
           <Text size="1" color="gray">
             Stableford
           </Text>
@@ -62,7 +62,7 @@ export function ScoreSummary({
           </Text>
         </Flex>
 
-        <Flex direction="column" align="center">
+        <Flex direction="column" align="center" gap="2">
           <Text size="1" color="gray">
             Birdies
           </Text>

--- a/src/components/scoring/Scorecard.tsx
+++ b/src/components/scoring/Scorecard.tsx
@@ -106,7 +106,7 @@ export function Scorecard({
   return (
     <Flex direction="column" gap="4">
       <Flex justify="between" align="center">
-        <Flex direction="column" gap="2">
+        <Flex direction="column" gap="3">
           <Heading size="4">{golfer.name}</Heading>
           <Text size="2" color="gray">
             HCP {golfer.handicap.toFixed(1)} → Playing {playingHandicap}

--- a/src/components/trips/TripCard.tsx
+++ b/src/components/trips/TripCard.tsx
@@ -29,8 +29,8 @@ export function TripCard({ trip, golferCount = 0 }: TripCardProps) {
 
   return (
     <Link to="/trips/$tripId" params={{ tripId: trip.id }} style={{ textDecoration: 'none' }}>
-      <Card asChild className="card-gold-hover">
-        <Flex direction="column" gap="3">
+      <Card className="card-gold-hover">
+        <Flex direction="column" gap="5">
           <Flex justify="between" align="start">
             <Heading size="4">{trip.name}</Heading>
             {isUpcoming && <Badge color="grass">Upcoming</Badge>}

--- a/src/routes/golfers/$golferId.tsx
+++ b/src/routes/golfers/$golferId.tsx
@@ -138,9 +138,9 @@ function GolferDetailPage() {
               radius="full"
               color="amber"
             />
-            <Flex direction="column" gap="2" style={{ flex: 1 }}>
+            <Flex direction="column" gap="3" style={{ flex: 1 }}>
               <Flex justify="between" align="start">
-                <Flex direction="column" gap="2">
+                <Flex direction="column" gap="3">
                   <Heading size="6">{golfer.name}</Heading>
                   <Badge size="2" color="grass" variant="soft">
                     HCP {golfer.handicap.toFixed(1)}
@@ -203,7 +203,7 @@ function GolferDetailPage() {
         {totalRounds > 0 && (
           <Grid columns="4" gap="3">
             <Card>
-              <Flex direction="column" align="center" gap="1">
+              <Flex direction="column" align="center" gap="2">
                 <Heading size="5" style={{ color: 'var(--amber-9)' }}>
                   {totalRounds}
                 </Heading>
@@ -213,7 +213,7 @@ function GolferDetailPage() {
               </Flex>
             </Card>
             <Card>
-              <Flex direction="column" align="center" gap="1">
+              <Flex direction="column" align="center" gap="2">
                 <Heading size="5" style={{ color: 'var(--amber-9)' }}>
                   {avgGross}
                 </Heading>
@@ -223,7 +223,7 @@ function GolferDetailPage() {
               </Flex>
             </Card>
             <Card>
-              <Flex direction="column" align="center" gap="1">
+              <Flex direction="column" align="center" gap="2">
                 <Heading size="5" style={{ color: 'var(--amber-9)' }}>
                   {avgStableford}
                 </Heading>
@@ -233,7 +233,7 @@ function GolferDetailPage() {
               </Flex>
             </Card>
             <Card>
-              <Flex direction="column" align="center" gap="1">
+              <Flex direction="column" align="center" gap="2">
                 <Heading size="5" style={{ color: 'var(--amber-9)' }}>
                   {totalBirdies}
                 </Heading>
@@ -265,7 +265,7 @@ function GolferDetailPage() {
                 >
                   <Card>
                     <Flex justify="between" align="center">
-                      <Flex direction="column" gap="2">
+                      <Flex direction="column" gap="3">
                         <Text weight="medium">{trip.tripName}</Text>
                         <Flex align="center" gap="2">
                           <Calendar size={12} />
@@ -323,7 +323,7 @@ function GolferDetailPage() {
               {rounds.slice(0, 5).map((round) => (
                 <Card key={round.roundId}>
                   <Flex justify="between" align="center">
-                    <Flex direction="column" gap="2">
+                    <Flex direction="column" gap="3">
                       <Text size="2" color="gray">
                         {round.roundDate.toLocaleDateString('en-US', {
                           month: 'short',

--- a/src/routes/trips/$tripId/golfers.tsx
+++ b/src/routes/trips/$tripId/golfers.tsx
@@ -78,7 +78,7 @@ function TripGolfersPage() {
   return (
     <Container size="2" py="6">
       <Flex direction="column" gap="5">
-        <Flex direction="column" gap="2">
+        <Flex direction="column" gap="3">
           <Heading size="7">Trip Golfers</Heading>
           <Text color="gray">{trip.name}</Text>
         </Flex>

--- a/src/routes/trips/$tripId/index.tsx
+++ b/src/routes/trips/$tripId/index.tsx
@@ -90,7 +90,7 @@ function TripDashboard() {
     <Container size="2" py="6">
       <Flex direction="column" gap="6">
         {/* Header */}
-        <Flex direction="column" gap="2">
+        <Flex direction="column" gap="3">
           <Heading size="8">{trip.name}</Heading>
           {trip.description && (
             <Text size="3" color="gray">
@@ -197,7 +197,7 @@ function TripDashboard() {
                   >
                     <Card asChild>
                       <Flex justify="between" align="center">
-                        <Flex direction="column" gap="2">
+                        <Flex direction="column" gap="3">
                           <Flex align="center" gap="2">
                             <Badge>Round {round.roundNumber}</Badge>
                             <Text weight="medium">{course?.name || 'Unknown Course'}</Text>

--- a/src/routes/trips/$tripId/leaderboards.tsx
+++ b/src/routes/trips/$tripId/leaderboards.tsx
@@ -224,7 +224,7 @@ function LeaderboardsPage() {
   return (
     <Container size="2" py="6">
       <Flex direction="column" gap="5">
-        <Flex direction="column" gap="2">
+        <Flex direction="column" gap="3">
           <Heading size="7">Leaderboards</Heading>
           <Text color="gray">{trip.name}</Text>
         </Flex>
@@ -295,7 +295,7 @@ function LeaderboardsPage() {
                             >
                               #{idx + 1}
                             </Badge>
-                            <Flex direction="column">
+                            <Flex direction="column" gap="2">
                               <Text weight="bold">{item.team.name}</Text>
                               <Text size="1" color="gray">
                                 {item.memberCount} members

--- a/src/routes/trips/$tripId/rounds/$roundId/index.tsx
+++ b/src/routes/trips/$tripId/rounds/$roundId/index.tsx
@@ -98,7 +98,7 @@ function RoundOverview() {
     <Container size="2" py="6">
       <Flex direction="column" gap="5">
         {/* Header */}
-        <Flex direction="column" gap="2">
+        <Flex direction="column" gap="3">
           <Flex align="center" gap="2">
             <Badge size="2">Round {round.roundNumber}</Badge>
           </Flex>
@@ -111,7 +111,7 @@ function RoundOverview() {
         {course && (
           <Card>
             <Grid columns="3" gap="3">
-              <Flex direction="column" align="center">
+              <Flex direction="column" align="center" gap="2">
                 <Text size="1" color="gray">
                   Par
                 </Text>
@@ -119,7 +119,7 @@ function RoundOverview() {
                   {course.totalPar}
                 </Text>
               </Flex>
-              <Flex direction="column" align="center">
+              <Flex direction="column" align="center" gap="2">
                 <Text size="1" color="gray">
                   Rating
                 </Text>
@@ -127,7 +127,7 @@ function RoundOverview() {
                   {course.courseRating ?? '-'}
                 </Text>
               </Flex>
-              <Flex direction="column" align="center">
+              <Flex direction="column" align="center" gap="2">
                 <Text size="1" color="gray">
                   Slope
                 </Text>
@@ -156,7 +156,7 @@ function RoundOverview() {
                   >
                     <Card asChild>
                       <Flex justify="between" align="center">
-                        <Flex direction="column" gap="2">
+                        <Flex direction="column" gap="3">
                           <Text weight="medium">{golfer.name}</Text>
                           <Text size="2" color="gray">
                             HCP {golfer.handicap.toFixed(1)}

--- a/src/routes/trips/$tripId/rounds/$roundId/scorecard.tsx
+++ b/src/routes/trips/$tripId/rounds/$roundId/scorecard.tsx
@@ -195,7 +195,7 @@ function ScorecardPage() {
   return (
     <Container size="2" py="6">
       <Flex direction="column" gap="5">
-        <Flex direction="column" gap="2">
+        <Flex direction="column" gap="3">
           <Heading size="6">{course.name}</Heading>
           <Text color="gray">Round {round.roundNumber}</Text>
         </Flex>

--- a/src/routes/trips/$tripId/rounds/index.tsx
+++ b/src/routes/trips/$tripId/rounds/index.tsx
@@ -59,7 +59,7 @@ function RoundsPage() {
     <Container size="2" py="6">
       <Flex direction="column" gap="5">
         <Flex justify="between" align="center">
-          <Flex direction="column" gap="2">
+          <Flex direction="column" gap="3">
             <Heading size="7">Rounds</Heading>
             <Text color="gray">{trip.name}</Text>
           </Flex>
@@ -83,7 +83,7 @@ function RoundsPage() {
                 >
                   <Card asChild>
                     <Flex justify="between" align="center">
-                      <Flex direction="column" gap="2">
+                      <Flex direction="column" gap="3">
                         <Flex align="center" gap="2">
                           <Badge>Round {round.roundNumber}</Badge>
                           <Text weight="medium">

--- a/src/routes/trips/$tripId/teams.tsx
+++ b/src/routes/trips/$tripId/teams.tsx
@@ -159,7 +159,7 @@ function TeamsPage() {
     <Container size="2" py="6">
       <Flex direction="column" gap="5">
         <Flex justify="between" align="center">
-          <Flex direction="column" gap="2">
+          <Flex direction="column" gap="3">
             <Heading size="7">Teams</Heading>
             <Text color="gray">{trip.name}</Text>
           </Flex>

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -83,24 +83,45 @@ TanStack DB's query builder has IVM constraints:
 
 ## Capsize Typography + Radix Gap
 
-**Issue**: Capsize generates aggressive negative margins via `::before`/`::after` pseudo-elements to trim leading/descender space from text. When combined with small Radix gaps (`gap="1"` = 4px), vertically stacked text elements can overlap.
+**Issue**: Capsize generates aggressive negative margins via `::before`/`::after` pseudo-elements to trim leading/descender space from text. When combined with small Radix gaps, vertically stacked text elements can appear crowded or overlap.
 
-**Solution**: Use `gap="2"` (8px) minimum for text-on-text column stacks:
+**Guidelines**:
+
+| Context | Recommended Gap | Example |
+|---------|-----------------|---------|
+| Page headers (title + subtitle) | `gap="3"` or `gap="4"` | Heading + description text |
+| Stat displays (label + value) | `gap="2"` | "Golfers" + "10" |
+| Card content with multiple sections | `gap="4"` | Title + description + metadata row |
+| Form fields (label + input) | `gap="1"` | Label + TextField (OK - inputs aren't capsize-trimmed) |
+| List items between cards | `gap="2"` or `gap="3"` | Card list spacing |
+
+**Examples**:
 ```tsx
-// ❌ DON'T - will cause text overlap
+// ❌ DON'T - will cause text overlap/crowding
 <Flex direction="column" gap="1">
   <Heading size="6">{title}</Heading>
   <Text size="2" color="gray">{subtitle}</Text>
 </Flex>
 
-// ✅ DO - adequate spacing for capsize
-<Flex direction="column" gap="2">
-  <Heading size="6">{title}</Heading>
-  <Text size="2" color="gray">{subtitle}</Text>
+// ✅ DO - page headers need gap="3"
+<Flex direction="column" gap="3">
+  <Heading size="7">{title}</Heading>
+  <Text color="gray">{subtitle}</Text>
+</Flex>
+
+// ✅ DO - stat cards need gap="2" minimum
+<Flex direction="column" align="center" gap="2">
+  <Text size="1" color="gray">Label</Text>
+  <Text size="5" weight="bold">{value}</Text>
+</Flex>
+
+// ✅ DO - cards with multiple text sections need gap="4"
+<Flex direction="column" gap="4">
+  <Heading size="4">{title}</Heading>
+  <Text color="gray">{description}</Text>
+  <Flex gap="4">{metadata}</Flex>
 </Flex>
 ```
-
-**Note**: Form fields (label + TextField) are fine with `gap="1"` since TextField is not a capsize-trimmed text element. Only text-to-text stacks need the larger gap.
 
 **Don't**: Override `line-height` in CSS - capsize computes precise line-heights based on font metrics.
 
@@ -130,3 +151,37 @@ export const startInstance = undefined
 ```
 
 **Symptom**: Black screen, no console errors, React never hydrates, SSR HTML is rendered but client JS fails silently.
+
+## Radix Card asChild + Flex Gap
+
+**Issue**: When using `<Card asChild>` with a direct `<Flex direction="column">` child, the gap property doesn't work. The Card's `display: block` overrides the Flex's `display: flex`, causing the gap to be ignored even though the CSS classes are merged correctly.
+
+**Diagnosis**: Use browser DevTools to inspect the element:
+```javascript
+// Check computed styles
+getComputedStyle(cardElement).display  // "block" - problem!
+getComputedStyle(cardElement).gap      // "48px" - set but ignored
+```
+
+**Root cause**: The `asChild` pattern merges classes but CSS specificity causes the Card's `display: block` to win over Flex's `display: flex`.
+
+**Solution**: Don't use `asChild` when you need Flex gap. Nest the Flex inside the Card instead:
+```tsx
+// ❌ DON'T - gap won't work
+<Card asChild>
+  <Flex direction="column" gap="5">
+    <Heading>{title}</Heading>
+    <Text>{description}</Text>
+  </Flex>
+</Card>
+
+// ✅ DO - gap works correctly
+<Card>
+  <Flex direction="column" gap="5">
+    <Heading>{title}</Heading>
+    <Text>{description}</Text>
+  </Flex>
+</Card>
+```
+
+**When asChild IS okay**: For horizontal Flex layouts where you just need `justify-between` and `align-center` without vertical stacking gaps.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -20,6 +20,13 @@
 - [x] **Cleaned up debug logs**: Removed console.log statements from ClientOnly.tsx and __root.tsx
 - [x] **Updated lessons.md**: Documented both the capsize gap issue and startInstance requirement
 
+### Session 2026-03-18: Additional Spacing Fixes
+
+- [x] **ScoreSummary.tsx**: Added `gap="2"` to all stat columns (Gross, Net, Stableford, Birdies)
+- [x] **$golferId.tsx**: Fixed stat cards (Rounds, Avg Gross, Avg Points, Birdies+) with `gap="2"`
+- [x] **$roundId/index.tsx**: Fixed course info cards (Par, Rating, Slope) with `gap="2"`
+- [x] **leaderboards.tsx**: Fixed team leaderboard text stacking with `gap="2"`
+
 ---
 
 ## Completed - Phase 1: Foundation


### PR DESCRIPTION
## Summary

Fixed the TripCard vertical spacing issue and systematically addressed capsize typography overlap throughout the app.

### Key Fix: Card asChild Pattern
The main issue was that `<Card asChild>` with `<Flex direction="column" gap="...">` doesn't work because Card's `display: block` overrides Flex's `display: flex`, causing gap to be ignored. The fix was removing `asChild` and nesting the Flex inside the Card:

```tsx
// ❌ Gap doesn't work
<Card asChild>
  <Flex direction="column" gap="5">

// ✅ Gap works correctly  
<Card>
  <Flex direction="column" gap="5">
```

### Components Fixed
- **TripCard.tsx**: Removed `asChild` pattern so Flex gap actually works
- **ScoreSummary.tsx**: Added `gap="2"` to all stat columns (Gross/Net/Stableford/Birdies)
- **Scorecard.tsx**: Changed golfer name + HCP header from `gap="2"` to `gap="3"`
- **GolferCard.tsx**: Changed name + email column from `gap="2"` to `gap="3"`

### Route Pages Fixed (headers/sections changed from gap="2" to gap="3")
- `trips/$tripId/index.tsx` - Trip detail header and round cards
- `trips/$tripId/rounds/index.tsx` - Rounds list header  
- `trips/$tripId/rounds/$roundId/index.tsx` - Round detail header and scorecards
- `trips/$tripId/rounds/$roundId/scorecard.tsx` - Scorecard page header
- `trips/$tripId/golfers.tsx` - Trip golfers header
- `trips/$tripId/leaderboards.tsx` - Leaderboards header
- `trips/$tripId/teams.tsx` - Teams header
- `golfers/$golferId.tsx` - Golfer detail stats and sections

## Root Cause

Two issues:
1. **Card asChild**: When using `asChild`, CSS specificity causes Card's `display: block` to override Flex's `display: flex`, making gap ineffective
2. **Capsize margins**: Capsize typography generates negative margins via pseudo-elements to trim text. Tight gaps (`gap="1"` or `gap="2"`) cause overlap when combined with these negative margins.

## Guidelines Added to lessons.md
- Never use `<Card asChild>` with `<Flex direction="column" gap="...">` - the gap won't work
- Use `gap="3"` or `gap="4"` for page headers with title + subtitle
- Use `gap="2"` minimum for stat displays (label + value)
- Cards with multiple text sections should use `gap="4"` or `gap="5"`

## Test Plan

- [x] Trips page - TripCard now shows proper spacing between title/description/metadata
- [x] Trip detail page - header and stats spaced properly
- [x] Round detail page - header and course info spaced properly
- [x] Scorecard page - golfer info and summary stats spaced properly (no overlap)
- [x] Golfer detail page - stats and sections spaced properly
- [x] Home page - quick links spaced properly

This pull request was AI-assisted by Isaac.