### PR TITLE
Add challenges feature and fix dialog closing bug

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -50,7 +50,11 @@
       "Bash(jj git remote:*)",
       "Bash(gh pr edit:*)",
       "Bash(jj new:*)",
-      "mcp__plugin_chrome-devtools-mcp_chrome-devtools__click"
+      "mcp__plugin_chrome-devtools-mcp_chrome-devtools__click",
+      "Bash(jj bookmark delete:*)",
+      "Bash(gh pr list:*)",
+      "mcp__plugin_chrome-devtools-mcp_chrome-devtools__press_key",
+      "Bash(pnpm build:*)"
     ]
   },
   "enabledPlugins": {

--- a/src/components/challenges/ChallengeCard.tsx
+++ b/src/components/challenges/ChallengeCard.tsx
@@ -1,0 +1,119 @@
+import { Card, Flex, Text, Badge, Button } from '@radix-ui/themes'
+import { Trophy, Trash2, Edit2 } from 'lucide-react'
+import type { Challenge, Golfer, Round, Hole } from '../../db/collections'
+import { getChallengeColor, getChallengeTypeLabel, isManualChallenge } from '../../lib/challenges'
+
+interface ChallengeCardProps {
+  challenge: Challenge
+  winner?: Golfer | null
+  winnerValue?: string
+  round?: Round | null
+  hole?: Hole | null
+  onEnterResults?: () => void
+  onEdit?: () => void
+  onDelete?: () => void
+}
+
+export function ChallengeCard({
+  challenge,
+  winner,
+  winnerValue,
+  round,
+  hole,
+  onEnterResults,
+  onEdit,
+  onDelete,
+}: ChallengeCardProps) {
+  const color = getChallengeColor(challenge.challengeType)
+  const typeLabel = getChallengeTypeLabel(challenge.challengeType)
+  const needsManualEntry = isManualChallenge(challenge.challengeType)
+
+  // Build scope context string
+  let scopeContext = ''
+  if (challenge.scope === 'hole' && hole && round) {
+    scopeContext = `Round ${round.roundNumber}, Hole ${hole.holeNumber}`
+  } else if (challenge.scope === 'round' && round) {
+    scopeContext = `Round ${round.roundNumber}`
+  } else if (challenge.scope === 'trip') {
+    scopeContext = 'Entire Trip'
+  }
+
+  return (
+    <Card>
+      <Flex direction="column" gap="3">
+        <Flex justify="between" align="start">
+          <Flex direction="column" gap="2">
+            <Flex align="center" gap="2">
+              <Badge color={color} variant="soft">
+                {typeLabel}
+              </Badge>
+              {scopeContext && (
+                <Text size="1" color="gray">
+                  {scopeContext}
+                </Text>
+              )}
+            </Flex>
+            <Text weight="medium" size="3">
+              {challenge.name}
+            </Text>
+          </Flex>
+
+          <Flex gap="1">
+            {onEdit && (
+              <Button variant="ghost" size="1" onClick={onEdit}>
+                <Edit2 size={14} />
+              </Button>
+            )}
+            {onDelete && (
+              <Button variant="ghost" size="1" color="red" onClick={onDelete}>
+                <Trash2 size={14} />
+              </Button>
+            )}
+          </Flex>
+        </Flex>
+
+        {challenge.description && (
+          <Text size="2" color="gray">
+            {challenge.description}
+          </Text>
+        )}
+
+        {challenge.prizeDescription && (
+          <Flex align="center" gap="1">
+            <Trophy size={12} style={{ color: 'var(--amber-9)' }} />
+            <Text size="1" color="gray">
+              {challenge.prizeDescription}
+            </Text>
+          </Flex>
+        )}
+
+        {/* Winner display or action button */}
+        {winner ? (
+          <Flex
+            align="center"
+            gap="2"
+            p="2"
+            style={{
+              backgroundColor: 'var(--amber-3)',
+              borderRadius: 'var(--radius-2)',
+            }}
+          >
+            <Trophy size={16} style={{ color: 'var(--amber-9)' }} />
+            <Text size="2" weight="medium">
+              {winner.name}
+            </Text>
+            {winnerValue && (
+              <Badge variant="soft" color="amber">
+                {winnerValue}
+              </Badge>
+            )}
+          </Flex>
+        ) : needsManualEntry && onEnterResults ? (
+          <Button variant="soft" size="1" onClick={onEnterResults}>
+            Enter Results
+          </Button>
+        ) : null}
+      </Flex>
+    </Card>
+  )
+}

--- a/src/components/challenges/ChallengeForm.tsx
+++ b/src/components/challenges/ChallengeForm.tsx
@@ -1,0 +1,268 @@
+import { Flex, Text, TextField, TextArea, Button, Select } from '@radix-ui/themes'
+import { useLiveQuery, eq } from '@tanstack/react-db'
+import {
+  challengeCollection,
+  roundCollection,
+  holeCollection,
+  type Challenge,
+} from '../../db/collections'
+import { getDefaultScope, getChallengeTypeLabel } from '../../lib/challenges'
+
+type ChallengeType = Challenge['challengeType']
+
+const CHALLENGE_TYPES: ChallengeType[] = [
+  'closest_to_pin',
+  'longest_drive',
+  'most_birdies',
+  'best_net',
+  'best_stableford',
+  'custom',
+]
+
+interface ChallengeFormProps {
+  tripId: string
+  challengeId?: string
+  initialData?: Partial<Challenge>
+  onSuccess?: () => void
+}
+
+export function ChallengeForm({
+  tripId,
+  challengeId,
+  initialData,
+  onSuccess,
+}: ChallengeFormProps) {
+  // Fetch rounds for this trip
+  const { data: rounds } = useLiveQuery(
+    (q) =>
+      q
+        .from({ round: roundCollection })
+        .where(({ round }) => eq(round.tripId, tripId))
+        .orderBy(({ round }) => round.roundNumber, 'asc'),
+    [tripId]
+  )
+
+  // Track form state via data attributes on the form element
+  // We use uncontrolled inputs with form data
+
+  function handleTypeChange(value: string, form: HTMLFormElement) {
+    const type = value as ChallengeType
+    const defaultScope = getDefaultScope(type)
+
+    // Update scope select
+    const scopeSelect = form.querySelector('[name="scopeDisplay"]') as HTMLElement
+    if (scopeSelect) {
+      // Radix Select doesn't support direct value setting, so we use a hidden input
+      const scopeHidden = form.querySelector('[name="scope"]') as HTMLInputElement
+      if (scopeHidden) {
+        scopeHidden.value = defaultScope
+      }
+    }
+
+    // Show/hide round and hole selectors based on scope
+    const roundSection = form.querySelector('[data-field="round"]') as HTMLElement
+    const holeSection = form.querySelector('[data-field="hole"]') as HTMLElement
+
+    if (roundSection) {
+      roundSection.style.display = defaultScope === 'trip' ? 'none' : 'flex'
+    }
+    if (holeSection) {
+      holeSection.style.display = defaultScope === 'hole' ? 'flex' : 'none'
+    }
+  }
+
+  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault()
+    const formData = new FormData(e.currentTarget)
+
+    const name = formData.get('name') as string
+    const description = formData.get('description') as string
+    const challengeType = formData.get('challengeType') as ChallengeType
+    const scope = formData.get('scope') as 'hole' | 'round' | 'trip'
+    const roundId = formData.get('roundId') as string
+    const holeId = formData.get('holeId') as string
+    const prizeDescription = formData.get('prizeDescription') as string
+
+    const data = {
+      tripId,
+      name,
+      description: description || '',
+      challengeType,
+      scope,
+      roundId: scope !== 'trip' && roundId ? roundId : null,
+      holeId: scope === 'hole' && holeId ? holeId : null,
+      prizeDescription: prizeDescription || '',
+    }
+
+    if (challengeId) {
+      // Update existing
+      challengeCollection.update(challengeId, (d) => {
+        Object.assign(d, data)
+      })
+    } else {
+      // Insert new
+      challengeCollection.insert({
+        id: crypto.randomUUID(),
+        ...data,
+      })
+    }
+
+    onSuccess?.()
+  }
+
+  const defaultType = initialData?.challengeType || 'closest_to_pin'
+  const defaultScope = initialData?.scope || getDefaultScope(defaultType)
+  const showRoundSelector = defaultScope !== 'trip'
+  const showHoleSelector = defaultScope === 'hole'
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <Flex direction="column" gap="4">
+        <Flex direction="column" gap="1">
+          <Text as="label" size="2" weight="medium">
+            Challenge Name
+          </Text>
+          <TextField.Root
+            name="name"
+            placeholder="KP Hole 7"
+            defaultValue={initialData?.name || ''}
+            required
+          />
+        </Flex>
+
+        <Flex direction="column" gap="1">
+          <Text as="label" size="2" weight="medium">
+            Type
+          </Text>
+          <Select.Root
+            name="challengeType"
+            defaultValue={defaultType}
+            onValueChange={(value) => {
+              const form = document.querySelector('form') as HTMLFormElement
+              if (form) handleTypeChange(value, form)
+            }}
+          >
+            <Select.Trigger />
+            <Select.Content>
+              {CHALLENGE_TYPES.map((type) => (
+                <Select.Item key={type} value={type}>
+                  {getChallengeTypeLabel(type)}
+                </Select.Item>
+              ))}
+            </Select.Content>
+          </Select.Root>
+        </Flex>
+
+        <input type="hidden" name="scope" defaultValue={defaultScope} />
+
+        <Flex
+          direction="column"
+          gap="1"
+          data-field="round"
+          style={{ display: showRoundSelector ? 'flex' : 'none' }}
+        >
+          <Text as="label" size="2" weight="medium">
+            Round
+          </Text>
+          <Select.Root name="roundId" defaultValue={initialData?.roundId || ''}>
+            <Select.Trigger placeholder="Select round" />
+            <Select.Content>
+              {(rounds || []).map((round) => (
+                <Select.Item key={round.id} value={round.id}>
+                  Round {round.roundNumber}
+                </Select.Item>
+              ))}
+            </Select.Content>
+          </Select.Root>
+        </Flex>
+
+        <HoleSelectorField
+          defaultRoundId={initialData?.roundId || (rounds?.[0]?.id ?? '')}
+          defaultHoleId={initialData?.holeId || ''}
+          showInitially={showHoleSelector}
+        />
+
+        <Flex direction="column" gap="1">
+          <Text as="label" size="2" weight="medium">
+            Description (optional)
+          </Text>
+          <TextArea
+            name="description"
+            placeholder="Details about this challenge..."
+            defaultValue={initialData?.description || ''}
+          />
+        </Flex>
+
+        <Flex direction="column" gap="1">
+          <Text as="label" size="2" weight="medium">
+            Prize (optional)
+          </Text>
+          <TextField.Root
+            name="prizeDescription"
+            placeholder="$20 pot"
+            defaultValue={initialData?.prizeDescription || ''}
+          />
+        </Flex>
+
+        <Button type="submit">{challengeId ? 'Save Changes' : 'Create Challenge'}</Button>
+      </Flex>
+    </form>
+  )
+}
+
+interface HoleSelectorFieldProps {
+  defaultRoundId: string
+  defaultHoleId: string
+  showInitially: boolean
+}
+
+function HoleSelectorField({
+  defaultRoundId,
+  defaultHoleId,
+  showInitially,
+}: HoleSelectorFieldProps) {
+  // Get the round to find its courseId
+  const { data: rounds } = useLiveQuery(
+    (q) => q.from({ round: roundCollection }),
+    []
+  )
+  const round = rounds?.find((r) => r.id === defaultRoundId)
+
+  // Get holes for the course, filtered to par 3s for KP
+  const { data: holes } = useLiveQuery(
+    (q) =>
+      round?.courseId
+        ? q
+            .from({ hole: holeCollection })
+            .where(({ hole }) => eq(hole.courseId, round.courseId))
+            .orderBy(({ hole }) => hole.holeNumber, 'asc')
+        : q.from({ hole: holeCollection }).where(() => false),
+    [round?.courseId]
+  )
+
+  // For KP, show only par 3s
+  const par3Holes = (holes || []).filter((h) => h.par === 3)
+
+  return (
+    <Flex
+      direction="column"
+      gap="1"
+      data-field="hole"
+      style={{ display: showInitially ? 'flex' : 'none' }}
+    >
+      <Text as="label" size="2" weight="medium">
+        Hole (Par 3s)
+      </Text>
+      <Select.Root name="holeId" defaultValue={defaultHoleId}>
+        <Select.Trigger placeholder="Select hole" />
+        <Select.Content>
+          {par3Holes.map((hole) => (
+            <Select.Item key={hole.id} value={hole.id}>
+              Hole {hole.holeNumber} (Par {hole.par})
+            </Select.Item>
+          ))}
+        </Select.Content>
+      </Select.Root>
+    </Flex>
+  )
+}

--- a/src/components/challenges/ChallengeResultEntry.tsx
+++ b/src/components/challenges/ChallengeResultEntry.tsx
@@ -1,0 +1,153 @@
+import { Flex, Text, TextField, Button, Checkbox, Avatar } from '@radix-ui/themes'
+import { Trophy } from 'lucide-react'
+import type { Challenge, Golfer, ChallengeResult } from '../../db/collections'
+import { challengeResultCollection } from '../../db/collections'
+import { parseKpDistance, formatKpDistance, determineWinner } from '../../lib/challenges'
+
+interface ChallengeResultEntryProps {
+  challenge: Challenge
+  golfers: Golfer[]
+  existingResults?: ChallengeResult[]
+  onSuccess?: () => void
+}
+
+function getInitials(name: string): string {
+  return name
+    .split(' ')
+    .map((n) => n[0])
+    .join('')
+    .toUpperCase()
+    .slice(0, 2)
+}
+
+export function ChallengeResultEntry({
+  challenge,
+  golfers,
+  existingResults = [],
+  onSuccess,
+}: ChallengeResultEntryProps) {
+  // Build a map of existing results by golferId
+  const existingByGolfer = new Map(existingResults.map((r) => [r.golferId, r]))
+
+  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault()
+    const formData = new FormData(e.currentTarget)
+
+    // Collect all results
+    const results: Array<{
+      golferId: string
+      participated: boolean
+      resultValue: string
+      resultNumeric: number | null
+    }> = []
+
+    for (const golfer of golfers) {
+      const participated = formData.get(`participated_${golfer.id}`) === 'on'
+      const rawValue = formData.get(`value_${golfer.id}`) as string
+
+      if (participated && rawValue?.trim()) {
+        const numeric = parseKpDistance(rawValue)
+        results.push({
+          golferId: golfer.id,
+          participated: true,
+          resultValue: numeric !== null ? formatKpDistance(numeric) : rawValue,
+          resultNumeric: numeric,
+        })
+      }
+    }
+
+    // Determine winner
+    const winnerId = determineWinner(results, challenge.challengeType)
+
+    // Delete old results for this challenge
+    for (const existing of existingResults) {
+      challengeResultCollection.delete(existing.id)
+    }
+
+    // Insert new results
+    for (const result of results) {
+      challengeResultCollection.insert({
+        id: crypto.randomUUID(),
+        challengeId: challenge.id,
+        golferId: result.golferId,
+        resultValue: result.resultValue,
+        resultNumeric: result.resultNumeric,
+        isWinner: result.golferId === winnerId,
+      })
+    }
+
+    onSuccess?.()
+  }
+
+  const isKpOrLd =
+    challenge.challengeType === 'closest_to_pin' ||
+    challenge.challengeType === 'longest_drive'
+
+  const placeholder =
+    challenge.challengeType === 'closest_to_pin'
+      ? "4'6\""
+      : challenge.challengeType === 'longest_drive'
+        ? '285 yards'
+        : 'Result'
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <Flex direction="column" gap="4">
+        <Text size="2" color="gray">
+          Enter results for each participant. The winner will be determined automatically.
+        </Text>
+
+        <Flex direction="column" gap="3">
+          {golfers.map((golfer) => {
+            const existing = existingByGolfer.get(golfer.id)
+            const defaultChecked = existing !== undefined
+            const defaultValue = existing?.resultValue || ''
+
+            return (
+              <Flex
+                key={golfer.id}
+                align="center"
+                gap="3"
+                p="2"
+                style={{
+                  backgroundColor: 'var(--gray-2)',
+                  borderRadius: 'var(--radius-2)',
+                }}
+              >
+                <Checkbox
+                  name={`participated_${golfer.id}`}
+                  defaultChecked={defaultChecked}
+                />
+                <Avatar
+                  size="2"
+                  fallback={getInitials(golfer.name)}
+                  radius="full"
+                />
+                <Text size="2" style={{ flex: 1, minWidth: 100 }}>
+                  {golfer.name}
+                </Text>
+                <TextField.Root
+                  name={`value_${golfer.id}`}
+                  placeholder={placeholder}
+                  defaultValue={defaultValue}
+                  style={{ width: 100 }}
+                />
+                {existing?.isWinner && (
+                  <Trophy size={16} style={{ color: 'var(--amber-9)' }} />
+                )}
+              </Flex>
+            )
+          })}
+        </Flex>
+
+        {isKpOrLd && (
+          <Text size="1" color="gray">
+            Enter distance in feet and inches (e.g., 4'6" or 4ft 6in)
+          </Text>
+        )}
+
+        <Button type="submit">Save Results</Button>
+      </Flex>
+    </form>
+  )
+}

--- a/src/db/collections.ts
+++ b/src/db/collections.ts
@@ -142,6 +142,13 @@ export const challengeResultSchema = z.object({
   isWinner: z.boolean().default(false),
 })
 
+// UI State collection for managing dialog open states (local-only)
+export const uiStateSchema = z.object({
+  id: z.string(),
+  dialogId: z.string(),
+  isOpen: z.boolean(),
+})
+
 // ============================================================================
 // Type exports
 // ============================================================================
@@ -158,6 +165,7 @@ export type Team = z.output<typeof teamSchema>
 export type TeamMember = z.output<typeof teamMemberSchema>
 export type Challenge = z.output<typeof challengeSchema>
 export type ChallengeResult = z.output<typeof challengeResultSchema>
+export type UIState = z.output<typeof uiStateSchema>
 
 // ============================================================================
 // Collections
@@ -244,5 +252,12 @@ export const challengeResultCollection = createCollection(
   localOnlyCollectionOptions({
     getKey: (item) => item.id,
     schema: challengeResultSchema,
+  })
+)
+
+export const uiStateCollection = createCollection(
+  localOnlyCollectionOptions({
+    getKey: (item) => item.id,
+    schema: uiStateSchema,
   })
 )

--- a/src/hooks/useDialogState.ts
+++ b/src/hooks/useDialogState.ts
@@ -1,0 +1,38 @@
+import { useLiveQuery, eq } from '@tanstack/react-db'
+import { uiStateCollection } from '../db/collections'
+
+/**
+ * Hook to manage dialog open state via TanStack DB collection.
+ * This allows dialogs to close properly after form submission.
+ *
+ * @param dialogId - Unique identifier for this dialog instance
+ * @returns [isOpen, setOpen] tuple
+ */
+export function useDialogState(dialogId: string): [boolean, (open: boolean) => void] {
+  const { data: uiStates } = useLiveQuery(
+    (q) =>
+      q.from({ ui: uiStateCollection }).where(({ ui }) => eq(ui.dialogId, dialogId)),
+    [dialogId]
+  )
+
+  const uiState = uiStates?.[0]
+  const isOpen = uiState?.isOpen ?? false
+
+  const setOpen = (open: boolean) => {
+    if (uiState) {
+      // Update existing state
+      uiStateCollection.update(uiState.id, (d) => {
+        d.isOpen = open
+      })
+    } else {
+      // Create new state entry
+      uiStateCollection.insert({
+        id: crypto.randomUUID(),
+        dialogId,
+        isOpen: open,
+      })
+    }
+  }
+
+  return [isOpen, setOpen]
+}

--- a/src/lib/challenges.ts
+++ b/src/lib/challenges.ts
@@ -1,0 +1,153 @@
+import type { Challenge } from '../db/collections'
+
+export type ChallengeType = Challenge['challengeType']
+
+/**
+ * Parse a distance string like "4'6\"" or "4ft 6in" into feet (decimal)
+ * Examples: "4'6\"" → 4.5, "12'" → 12, "3ft 2in" → 3.167
+ */
+export function parseKpDistance(input: string): number | null {
+  if (!input?.trim()) return null
+
+  const normalized = input.trim().toLowerCase()
+
+  // Try feet'inches" format: 4'6" or 4' 6"
+  const feetInchesMatch = normalized.match(/^(\d+(?:\.\d+)?)'?\s*(\d+(?:\.\d+)?)?[""]?$/)
+  if (feetInchesMatch) {
+    const feet = parseFloat(feetInchesMatch[1])
+    const inches = feetInchesMatch[2] ? parseFloat(feetInchesMatch[2]) : 0
+    return feet + inches / 12
+  }
+
+  // Try "Xft Yin" format
+  const ftInMatch = normalized.match(/^(\d+(?:\.\d+)?)\s*(?:ft|feet)?\s*(\d+(?:\.\d+)?)?\s*(?:in|inch|inches)?$/)
+  if (ftInMatch) {
+    const feet = parseFloat(ftInMatch[1])
+    const inches = ftInMatch[2] ? parseFloat(ftInMatch[2]) : 0
+    return feet + inches / 12
+  }
+
+  // Try plain number (assumed feet)
+  const plainNumber = parseFloat(normalized)
+  if (!isNaN(plainNumber)) {
+    return plainNumber
+  }
+
+  return null
+}
+
+/**
+ * Format feet (decimal) to feet'inches" string
+ * Examples: 4.5 → "4'6\"", 12 → "12'0\""
+ */
+export function formatKpDistance(feet: number): string {
+  const wholeFeet = Math.floor(feet)
+  const inches = Math.round((feet - wholeFeet) * 12)
+
+  // Handle rounding up to next foot
+  if (inches === 12) {
+    return `${wholeFeet + 1}'0"`
+  }
+
+  return `${wholeFeet}'${inches}"`
+}
+
+/**
+ * Check if a challenge type requires manual result entry
+ */
+export function isManualChallenge(type: ChallengeType): boolean {
+  return type === 'closest_to_pin' || type === 'longest_drive' || type === 'custom'
+}
+
+/**
+ * Check if a challenge type is auto-calculated from round data
+ */
+export function isAutoCalculatedChallenge(type: ChallengeType): boolean {
+  return type === 'most_birdies' || type === 'best_net' || type === 'best_stableford'
+}
+
+/**
+ * Get Radix color for challenge type badge
+ */
+export function getChallengeColor(type: ChallengeType): 'amber' | 'grass' | 'blue' | 'purple' | 'orange' | 'gray' {
+  switch (type) {
+    case 'closest_to_pin':
+      return 'amber'
+    case 'longest_drive':
+      return 'grass'
+    case 'most_birdies':
+      return 'blue'
+    case 'best_net':
+      return 'purple'
+    case 'best_stableford':
+      return 'orange'
+    case 'custom':
+    default:
+      return 'gray'
+  }
+}
+
+/**
+ * Get human-readable label for challenge type
+ */
+export function getChallengeTypeLabel(type: ChallengeType): string {
+  switch (type) {
+    case 'closest_to_pin':
+      return 'Closest to Pin'
+    case 'longest_drive':
+      return 'Longest Drive'
+    case 'most_birdies':
+      return 'Most Birdies'
+    case 'best_net':
+      return 'Best Net'
+    case 'best_stableford':
+      return 'Best Stableford'
+    case 'custom':
+      return 'Custom'
+    default:
+      return type
+  }
+}
+
+/**
+ * Get default scope for a challenge type
+ */
+export function getDefaultScope(type: ChallengeType): 'hole' | 'round' | 'trip' {
+  switch (type) {
+    case 'closest_to_pin':
+    case 'longest_drive':
+      return 'hole'
+    case 'most_birdies':
+    case 'best_net':
+    case 'best_stableford':
+      return 'round'
+    case 'custom':
+    default:
+      return 'trip'
+  }
+}
+
+/**
+ * Determine winner from results (lowest distance for KP, highest for LD)
+ */
+export function determineWinner(
+  results: Array<{ golferId: string; resultNumeric: number | null }>,
+  type: ChallengeType
+): string | null {
+  const validResults = results.filter((r) => r.resultNumeric !== null)
+  if (validResults.length === 0) return null
+
+  if (type === 'closest_to_pin') {
+    // Lowest distance wins
+    const winner = validResults.reduce((min, r) =>
+      r.resultNumeric! < min.resultNumeric! ? r : min
+    )
+    return winner.golferId
+  }
+
+  // For longest_drive and others, highest value wins
+  const winner = validResults.reduce((max, r) =>
+    r.resultNumeric! > max.resultNumeric! ? r : max
+  )
+  return winner.golferId
+}

--- a/src/routes/golfers/$golferId.tsx
+++ b/src/routes/golfers/$golferId.tsx
@@ -14,6 +14,7 @@ import {
 } from '@radix-ui/themes'
 import { ArrowLeft, Mail, Phone, Trophy, Flag, Calendar, Edit } from 'lucide-react'
 import { useLiveQuery, eq } from '@tanstack/react-db'
+import { useDialogState } from '../../hooks/useDialogState'
 import {
   golferCollection,
   tripGolferCollection,
@@ -39,6 +40,7 @@ function getInitials(name: string): string {
 
 function GolferDetailPage() {
   const { golferId } = Route.useParams()
+  const [editDialogOpen, setEditDialogOpen] = useDialogState(`edit-golfer-${golferId}`)
 
   const { data: golfers } = useLiveQuery(
     (q) =>
@@ -146,7 +148,7 @@ function GolferDetailPage() {
                     HCP {golfer.handicap.toFixed(1)}
                   </Badge>
                 </Flex>
-                <Dialog.Root>
+                <Dialog.Root open={editDialogOpen} onOpenChange={setEditDialogOpen}>
                   <Dialog.Trigger>
                     <Button variant="soft" size="1">
                       <Edit size={14} />
@@ -164,12 +166,7 @@ function GolferDetailPage() {
                           phone: golfer.phone,
                           handicap: golfer.handicap,
                         }}
-                        onSuccess={() => {
-                          const closeButton = document.querySelector(
-                            '[data-radix-dialog-close]'
-                          ) as HTMLButtonElement
-                          closeButton?.click()
-                        }}
+                        onSuccess={() => setEditDialogOpen(false)}
                       />
                     </Flex>
                   </Dialog.Content>

--- a/src/routes/golfers/index.tsx
+++ b/src/routes/golfers/index.tsx
@@ -2,6 +2,7 @@ import { createFileRoute } from '@tanstack/react-router'
 import { Container, Flex, Heading, Button, Dialog } from '@radix-ui/themes'
 import { Plus } from 'lucide-react'
 import { useLiveQuery } from '@tanstack/react-db'
+import { useDialogState } from '../../hooks/useDialogState'
 import { golferCollection } from '../../db/collections'
 import { GolferCard } from '../../components/golfers/GolferCard'
 import { GolferForm } from '../../components/golfers/GolferForm'
@@ -13,6 +14,8 @@ export const Route = createFileRoute('/golfers/')({
 })
 
 function GolfersPage() {
+  const [addDialogOpen, setAddDialogOpen] = useDialogState('add-golfer')
+
   const { data: golfers, isLoading } = useLiveQuery(
     (q) =>
       q.from({ golfer: golferCollection }).orderBy(({ golfer }) => golfer.name, 'asc'),
@@ -37,7 +40,7 @@ function GolfersPage() {
       <Flex direction="column" gap="4">
         <Flex justify="between" align="center">
           <Heading size="7">Golfers</Heading>
-          <Dialog.Root>
+          <Dialog.Root open={addDialogOpen} onOpenChange={setAddDialogOpen}>
             <Dialog.Trigger>
               <Button color="grass">
                 <Plus size={16} />
@@ -50,15 +53,7 @@ function GolfersPage() {
                 Add a new golfer to your directory
               </Dialog.Description>
               <Flex direction="column" gap="4" pt="4">
-                <GolferForm
-                  onSuccess={() => {
-                    // Dialog will close automatically via form reset
-                    const closeButton = document.querySelector(
-                      '[data-radix-dialog-close]'
-                    ) as HTMLButtonElement
-                    closeButton?.click()
-                  }}
-                />
+                <GolferForm onSuccess={() => setAddDialogOpen(false)} />
               </Flex>
             </Dialog.Content>
           </Dialog.Root>
@@ -75,7 +70,7 @@ function GolfersPage() {
             title="No golfers yet"
             description="Add golfers to start tracking scores"
             action={
-              <Dialog.Root>
+              <Dialog.Root open={addDialogOpen} onOpenChange={setAddDialogOpen}>
                 <Dialog.Trigger>
                   <Button color="grass">
                     <Plus size={16} />
@@ -85,7 +80,7 @@ function GolfersPage() {
                 <Dialog.Content maxWidth="400px">
                   <Dialog.Title>Add Golfer</Dialog.Title>
                   <Flex direction="column" gap="4" pt="4">
-                    <GolferForm />
+                    <GolferForm onSuccess={() => setAddDialogOpen(false)} />
                   </Flex>
                 </Dialog.Content>
               </Dialog.Root>

--- a/src/routes/trips/$tripId/challenges.tsx
+++ b/src/routes/trips/$tripId/challenges.tsx
@@ -1,0 +1,404 @@
+import { createFileRoute } from '@tanstack/react-router'
+import {
+  Container,
+  Flex,
+  Heading,
+  Text,
+  Button,
+  Dialog,
+} from '@radix-ui/themes'
+import { Plus, Trophy } from 'lucide-react'
+import { useLiveQuery, eq } from '@tanstack/react-db'
+import { useDialogState } from '../../../hooks/useDialogState'
+import {
+  tripCollection,
+  challengeCollection,
+  challengeResultCollection,
+  golferCollection,
+  tripGolferCollection,
+  roundCollection,
+  holeCollection,
+  roundSummaryCollection,
+  type Challenge,
+  type ChallengeResult,
+} from '../../../db/collections'
+import { EmptyState } from '../../../components/ui/EmptyState'
+import { ChallengeCard } from '../../../components/challenges/ChallengeCard'
+import { ChallengeForm } from '../../../components/challenges/ChallengeForm'
+import { ChallengeResultEntry } from '../../../components/challenges/ChallengeResultEntry'
+import { isAutoCalculatedChallenge } from '../../../lib/challenges'
+
+export const Route = createFileRoute('/trips/$tripId/challenges')({
+  ssr: false,
+  component: ChallengesPage,
+})
+
+function ChallengesPage() {
+  const { tripId } = Route.useParams()
+  const [addChallengeDialogOpen, setAddChallengeDialogOpen] = useDialogState(`add-challenge-${tripId}`)
+
+  // Fetch trip
+  const { data: trips } = useLiveQuery(
+    (q) => q.from({ trip: tripCollection }).where(({ trip }) => eq(trip.id, tripId)),
+    [tripId]
+  )
+  const trip = trips?.[0]
+
+  // Fetch all challenges for this trip
+  const { data: challenges } = useLiveQuery(
+    (q) =>
+      q
+        .from({ challenge: challengeCollection })
+        .where(({ challenge }) => eq(challenge.tripId, tripId)),
+    [tripId]
+  )
+
+  // Fetch all challenge results
+  const { data: allResults } = useLiveQuery(
+    (q) => q.from({ result: challengeResultCollection }),
+    []
+  )
+
+  // Fetch golfers for result entry
+  const { data: golfers } = useLiveQuery(
+    (q) => q.from({ golfer: golferCollection }),
+    []
+  )
+  const golferMap = new Map((golfers || []).map((g) => [g.id, g]))
+
+  // Fetch trip golfers (accepted only)
+  const { data: tripGolfers } = useLiveQuery(
+    (q) =>
+      q
+        .from({ tg: tripGolferCollection })
+        .where(({ tg }) => eq(tg.tripId, tripId))
+        .where(({ tg }) => eq(tg.status, 'accepted')),
+    [tripId]
+  )
+  const tripGolferIds = new Set((tripGolfers || []).map((tg) => tg.golferId))
+  const tripGolferList = (golfers || []).filter((g) => tripGolferIds.has(g.id))
+
+  // Fetch rounds for context
+  const { data: rounds } = useLiveQuery(
+    (q) =>
+      q
+        .from({ round: roundCollection })
+        .where(({ round }) => eq(round.tripId, tripId)),
+    [tripId]
+  )
+  const roundMap = new Map((rounds || []).map((r) => [r.id, r]))
+
+  // Fetch holes for context
+  const { data: holes } = useLiveQuery((q) => q.from({ hole: holeCollection }), [])
+  const holeMap = new Map((holes || []).map((h) => [h.id, h]))
+
+  // Fetch round summaries for auto-calculated challenges
+  const { data: roundSummaries } = useLiveQuery(
+    (q) => q.from({ summary: roundSummaryCollection }),
+    []
+  )
+
+  // Group results by challengeId
+  const resultsByChallengeId = new Map<string, ChallengeResult[]>()
+  for (const result of allResults || []) {
+    const existing = resultsByChallengeId.get(result.challengeId) || []
+    existing.push(result)
+    resultsByChallengeId.set(result.challengeId, existing)
+  }
+
+  // Find winner for each challenge
+  function getWinnerInfo(challenge: Challenge) {
+    // For auto-calculated challenges, compute from round summaries
+    if (isAutoCalculatedChallenge(challenge.challengeType)) {
+      return computeAutoWinner(challenge)
+    }
+
+    // For manual challenges, look at results
+    const results = resultsByChallengeId.get(challenge.id) || []
+    const winnerResult = results.find((r) => r.isWinner)
+    if (!winnerResult) return { winner: null, winnerValue: undefined }
+
+    const winner = golferMap.get(winnerResult.golferId)
+    return { winner: winner || null, winnerValue: winnerResult.resultValue }
+  }
+
+  function computeAutoWinner(challenge: Challenge) {
+    // Filter summaries to trip golfers and optionally to specific round
+    let relevantSummaries = (roundSummaries || []).filter((s) =>
+      tripGolferIds.has(s.golferId)
+    )
+
+    if (challenge.roundId) {
+      relevantSummaries = relevantSummaries.filter(
+        (s) => s.roundId === challenge.roundId
+      )
+    } else {
+      // Trip-wide: filter to rounds in this trip
+      const tripRoundIds = new Set((rounds || []).map((r) => r.id))
+      relevantSummaries = relevantSummaries.filter((s) =>
+        tripRoundIds.has(s.roundId)
+      )
+    }
+
+    if (relevantSummaries.length === 0) {
+      return { winner: null, winnerValue: undefined }
+    }
+
+    // Aggregate by golfer
+    const aggregates = new Map<
+      string,
+      { totalBirdies: number; totalStableford: number; bestNet: number }
+    >()
+
+    for (const s of relevantSummaries) {
+      const existing = aggregates.get(s.golferId) || {
+        totalBirdies: 0,
+        totalStableford: 0,
+        bestNet: Infinity,
+      }
+      existing.totalBirdies += s.birdiesOrBetter
+      existing.totalStableford += s.totalStableford
+      existing.bestNet = Math.min(existing.bestNet, s.totalNet)
+      aggregates.set(s.golferId, existing)
+    }
+
+    let winnerId: string | null = null
+    let winnerValue = ''
+
+    if (challenge.challengeType === 'most_birdies') {
+      let maxBirdies = -1
+      for (const [golferId, agg] of aggregates) {
+        if (agg.totalBirdies > maxBirdies) {
+          maxBirdies = agg.totalBirdies
+          winnerId = golferId
+          winnerValue = `${agg.totalBirdies} birdies`
+        }
+      }
+    } else if (challenge.challengeType === 'best_net') {
+      let bestNet = Infinity
+      for (const [golferId, agg] of aggregates) {
+        if (agg.bestNet < bestNet) {
+          bestNet = agg.bestNet
+          winnerId = golferId
+          winnerValue = `${agg.bestNet}`
+        }
+      }
+    } else if (challenge.challengeType === 'best_stableford') {
+      let maxPts = -1
+      for (const [golferId, agg] of aggregates) {
+        if (agg.totalStableford > maxPts) {
+          maxPts = agg.totalStableford
+          winnerId = golferId
+          winnerValue = `${agg.totalStableford} pts`
+        }
+      }
+    }
+
+    const winner = winnerId ? golferMap.get(winnerId) : null
+    return { winner: winner || null, winnerValue }
+  }
+
+  function handleDeleteChallenge(challengeId: string) {
+    // Delete results first
+    const results = resultsByChallengeId.get(challengeId) || []
+    for (const r of results) {
+      challengeResultCollection.delete(r.id)
+    }
+    // Delete challenge
+    challengeCollection.delete(challengeId)
+  }
+
+  if (!trip) {
+    return (
+      <Container size="2" py="6">
+        <Text>Trip not found</Text>
+      </Container>
+    )
+  }
+
+  // Separate active (no winner yet) and completed challenges
+  const activeChallenges: Challenge[] = []
+  const completedChallenges: Challenge[] = []
+
+  for (const challenge of challenges || []) {
+    const { winner } = getWinnerInfo(challenge)
+    if (winner) {
+      completedChallenges.push(challenge)
+    } else {
+      activeChallenges.push(challenge)
+    }
+  }
+
+  const hasChallenges = (challenges || []).length > 0
+
+  return (
+    <Container size="2" py="6">
+      <Flex direction="column" gap="5">
+        <Flex justify="between" align="center">
+          <Flex direction="column" gap="3">
+            <Heading size="7">Challenges</Heading>
+            <Text color="gray">{trip.name}</Text>
+          </Flex>
+
+          <Dialog.Root open={addChallengeDialogOpen} onOpenChange={setAddChallengeDialogOpen}>
+            <Dialog.Trigger>
+              <Button>
+                <Plus size={16} />
+                Add Challenge
+              </Button>
+            </Dialog.Trigger>
+            <Dialog.Content maxWidth="400px">
+              <Dialog.Title>Create Challenge</Dialog.Title>
+              <Flex direction="column" gap="4" pt="4">
+                <ChallengeForm
+                  tripId={tripId}
+                  onSuccess={() => setAddChallengeDialogOpen(false)}
+                />
+              </Flex>
+            </Dialog.Content>
+          </Dialog.Root>
+        </Flex>
+
+        {hasChallenges ? (
+          <Flex direction="column" gap="6">
+            {/* Active Challenges */}
+            {activeChallenges.length > 0 && (
+              <Flex direction="column" gap="3">
+                <Heading size="4">Active</Heading>
+                <Flex direction="column" gap="3">
+                  {activeChallenges.map((challenge) => (
+                    <ChallengeCardWithDialogs
+                      key={challenge.id}
+                      challenge={challenge}
+                      roundMap={roundMap}
+                      holeMap={holeMap}
+                      golferMap={golferMap}
+                      tripGolferList={tripGolferList}
+                      results={resultsByChallengeId.get(challenge.id) || []}
+                      onDelete={() => handleDeleteChallenge(challenge.id)}
+                    />
+                  ))}
+                </Flex>
+              </Flex>
+            )}
+
+            {/* Completed Challenges */}
+            {completedChallenges.length > 0 && (
+              <Flex direction="column" gap="3">
+                <Flex align="center" gap="2">
+                  <Trophy size={18} style={{ color: 'var(--amber-9)' }} />
+                  <Heading size="4">Completed</Heading>
+                </Flex>
+                <Flex direction="column" gap="3">
+                  {completedChallenges.map((challenge) => {
+                    const { winner, winnerValue } = getWinnerInfo(challenge)
+                    return (
+                      <ChallengeCard
+                        key={challenge.id}
+                        challenge={challenge}
+                        winner={winner}
+                        winnerValue={winnerValue}
+                        round={challenge.roundId ? roundMap.get(challenge.roundId) : null}
+                        hole={challenge.holeId ? holeMap.get(challenge.holeId) : null}
+                        onDelete={() => handleDeleteChallenge(challenge.id)}
+                      />
+                    )
+                  })}
+                </Flex>
+              </Flex>
+            )}
+          </Flex>
+        ) : (
+          <EmptyState
+            title="No challenges yet"
+            description="Create challenges like Closest to Pin or Longest Drive"
+            action={
+              <Dialog.Root open={addChallengeDialogOpen} onOpenChange={setAddChallengeDialogOpen}>
+                <Dialog.Trigger>
+                  <Button>
+                    <Plus size={16} />
+                    Create Challenge
+                  </Button>
+                </Dialog.Trigger>
+                <Dialog.Content maxWidth="400px">
+                  <Dialog.Title>Create Challenge</Dialog.Title>
+                  <Flex direction="column" gap="4" pt="4">
+                    <ChallengeForm
+                      tripId={tripId}
+                      onSuccess={() => setAddChallengeDialogOpen(false)}
+                    />
+                  </Flex>
+                </Dialog.Content>
+              </Dialog.Root>
+            }
+          />
+        )}
+      </Flex>
+    </Container>
+  )
+}
+
+// Separate component to handle per-challenge dialogs
+interface ChallengeCardWithDialogsProps {
+  challenge: Challenge
+  roundMap: Map<string, ReturnType<typeof roundCollection.get> & {}>
+  holeMap: Map<string, ReturnType<typeof holeCollection.get> & {}>
+  golferMap: Map<string, ReturnType<typeof golferCollection.get> & {}>
+  tripGolferList: Array<ReturnType<typeof golferCollection.get> & {}>
+  results: ChallengeResult[]
+  onDelete: () => void
+}
+
+function ChallengeCardWithDialogs({
+  challenge,
+  roundMap,
+  holeMap,
+  golferMap,
+  tripGolferList,
+  results,
+  onDelete,
+}: ChallengeCardWithDialogsProps) {
+  const [resultDialogOpen, setResultDialogOpen] = useDialogState(`results-${challenge.id}`)
+  const round = challenge.roundId ? roundMap.get(challenge.roundId) : null
+  const hole = challenge.holeId ? holeMap.get(challenge.holeId) : null
+
+  // Find winner from results
+  const winnerResult = results.find((r) => r.isWinner)
+  const winner = winnerResult ? golferMap.get(winnerResult.golferId) : null
+
+  return (
+    <Flex direction="column" gap="2">
+      <ChallengeCard
+        challenge={challenge}
+        winner={winner}
+        winnerValue={winnerResult?.resultValue}
+        round={round}
+        hole={hole}
+        onDelete={onDelete}
+        onEnterResults={undefined} // Handled by dialog below
+      />
+
+      {/* Result Entry Dialog - rendered separately to handle open state */}
+      {!winner && !isAutoCalculatedChallenge(challenge.challengeType) && (
+        <Dialog.Root open={resultDialogOpen} onOpenChange={setResultDialogOpen}>
+          <Dialog.Trigger>
+            <Button variant="soft" size="1">
+              Enter Results
+            </Button>
+          </Dialog.Trigger>
+          <Dialog.Content maxWidth="450px">
+            <Dialog.Title>Enter Results: {challenge.name}</Dialog.Title>
+            <Flex direction="column" gap="4" pt="4">
+              <ChallengeResultEntry
+                challenge={challenge}
+                golfers={tripGolferList}
+                existingResults={results}
+                onSuccess={() => setResultDialogOpen(false)}
+              />
+            </Flex>
+          </Dialog.Content>
+        </Dialog.Root>
+      )}
+    </Flex>
+  )
+}

--- a/src/routes/trips/$tripId/index.tsx
+++ b/src/routes/trips/$tripId/index.tsx
@@ -16,6 +16,7 @@ import {
   Trophy,
   Flag,
   ChevronRight,
+  Target,
 } from 'lucide-react'
 import { useLiveQuery, eq, count } from '@tanstack/react-db'
 import {
@@ -23,6 +24,7 @@ import {
   tripGolferCollection,
   roundCollection,
   courseCollection,
+  challengeCollection,
 } from '../../../db/collections'
 import { StatCard } from '../../../components/ui/StatCard'
 
@@ -74,6 +76,16 @@ function TripDashboard() {
   )
 
   const courseMap = new Map((courses || []).map((c) => [c.id, c]))
+
+  // Fetch challenges for badge count
+  const { data: challenges } = useLiveQuery(
+    (q) =>
+      q
+        .from({ challenge: challengeCollection })
+        .where(({ challenge }) => eq(challenge.tripId, tripId)),
+    [tripId]
+  )
+  const challengeCount = challenges?.length ?? 0
 
   if (!trip) {
     return (
@@ -154,6 +166,23 @@ function TripDashboard() {
                   <Flex align="center" gap="2">
                     <Flag size={20} />
                     <Text weight="medium">Teams</Text>
+                  </Flex>
+                  <ChevronRight size={16} />
+                </Flex>
+              </Card>
+            </Link>
+
+            <Link to="/trips/$tripId/challenges" params={{ tripId }}>
+              <Card asChild>
+                <Flex justify="between" align="center">
+                  <Flex align="center" gap="2">
+                    <Target size={20} />
+                    <Text weight="medium">Challenges</Text>
+                    {challengeCount > 0 && (
+                      <Badge size="1" color="amber">
+                        {challengeCount}
+                      </Badge>
+                    )}
                   </Flex>
                   <ChevronRight size={16} />
                 </Flex>

--- a/src/routes/trips/$tripId/teams.tsx
+++ b/src/routes/trips/$tripId/teams.tsx
@@ -13,6 +13,7 @@ import {
 } from '@radix-ui/themes'
 import { Plus, X } from 'lucide-react'
 import { useLiveQuery, eq } from '@tanstack/react-db'
+import { useDialogState } from '../../../hooks/useDialogState'
 import {
   tripCollection,
   golferCollection,
@@ -47,6 +48,7 @@ const TEAM_COLORS = [
 
 function TeamsPage() {
   const { tripId } = Route.useParams()
+  const [addTeamDialogOpen, setAddTeamDialogOpen] = useDialogState(`add-team-${tripId}`)
 
   const { data: trips } = useLiveQuery(
     (q) => q.from({ trip: tripCollection }).where(({ trip }) => eq(trip.id, tripId)),
@@ -116,10 +118,7 @@ function TeamsPage() {
     })
 
     // Close dialog
-    const closeButton = document.querySelector(
-      '[data-radix-dialog-close]'
-    ) as HTMLButtonElement
-    closeButton?.click()
+    setAddTeamDialogOpen(false)
   }
 
   function addToTeam(teamId: string, golferId: string) {
@@ -164,7 +163,7 @@ function TeamsPage() {
             <Text color="gray">{trip.name}</Text>
           </Flex>
 
-          <Dialog.Root>
+          <Dialog.Root open={addTeamDialogOpen} onOpenChange={setAddTeamDialogOpen}>
             <Dialog.Trigger>
               <Button>
                 <Plus size={16} />
@@ -308,7 +307,7 @@ function TeamsPage() {
             title="No teams yet"
             description="Create teams to track team competitions"
             action={
-              <Dialog.Root>
+              <Dialog.Root open={addTeamDialogOpen} onOpenChange={setAddTeamDialogOpen}>
                 <Dialog.Trigger>
                   <Button>
                     <Plus size={16} />

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -185,3 +185,58 @@ getComputedStyle(cardElement).gap      // "48px" - set but ignored
 ```
 
 **When asChild IS okay**: For horizontal Flex layouts where you just need `justify-between` and `align-center` without vertical stacking gaps.
+
+## Radix Dialog Closing Pattern
+
+**Issue**: Using `document.querySelector('[data-radix-dialog-close]')?.click()` to close dialogs fails when no `<Dialog.Close>` element exists in the dialog. The selector returns `null` and the dialog stays open after form submission.
+
+**Root cause**: The pattern assumes a `<Dialog.Close>` button exists, but many dialogs only have action buttons (Save, Submit) without an explicit close button.
+
+**Solution**: Use controlled dialog state via TanStack DB collection:
+
+```tsx
+// src/hooks/useDialogState.ts
+import { useLiveQuery, eq } from '@tanstack/react-db'
+import { uiStateCollection } from '../db/collections'
+
+export function useDialogState(dialogId: string): [boolean, (open: boolean) => void] {
+  const { data: uiStates } = useLiveQuery(
+    (q) => q.from({ ui: uiStateCollection }).where(({ ui }) => eq(ui.dialogId, dialogId)),
+    [dialogId]
+  )
+  const isOpen = uiStates?.[0]?.isOpen ?? false
+
+  const setOpen = (open: boolean) => {
+    const existing = uiStates?.[0]
+    if (existing) {
+      uiStateCollection.update(existing.id, (d) => { d.isOpen = open })
+    } else {
+      uiStateCollection.insert({ id: crypto.randomUUID(), dialogId, isOpen: open })
+    }
+  }
+
+  return [isOpen, setOpen]
+}
+
+// Usage in component
+function MyPage() {
+  const [dialogOpen, setDialogOpen] = useDialogState('edit-item-123')
+
+  return (
+    <Dialog.Root open={dialogOpen} onOpenChange={setDialogOpen}>
+      <Dialog.Trigger>
+        <Button>Edit</Button>
+      </Dialog.Trigger>
+      <Dialog.Content>
+        <MyForm onSuccess={() => setDialogOpen(false)} />
+      </Dialog.Content>
+    </Dialog.Root>
+  )
+}
+```
+
+**Benefits**:
+- Works with any dialog, no `<Dialog.Close>` element required
+- Follows TanStack DB state management pattern (no useState)
+- Dialog state persists correctly through re-renders
+- Clean separation between form logic and dialog control

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -27,6 +27,27 @@
 - [x] **$roundId/index.tsx**: Fixed course info cards (Par, Rating, Slope) with `gap="2"`
 - [x] **leaderboards.tsx**: Fixed team leaderboard text stacking with `gap="2"`
 
+### Session 2026-03-18: Phase 5 - Challenges + Dialog Bug Fix
+
+#### Challenges Feature (Complete)
+- [x] **lib/challenges.ts**: Utility functions for KP distance parsing, formatting, winner determination, type labels
+- [x] **ChallengeCard.tsx**: Display component with type badge, scope context, winner display, action buttons
+- [x] **ChallengeForm.tsx**: Create/edit dialog form with type selector, scope settings, round/hole selectors
+- [x] **ChallengeResultEntry.tsx**: Manual result entry with golfer list, distance inputs, auto-winner selection
+- [x] **challenges.tsx route**: Main challenges page with active/completed sections, CRUD operations
+- [x] **Trip dashboard**: Added Challenges link with Target icon and badge count
+
+#### Dialog Closing Bug Fix
+- [x] **Root cause**: `document.querySelector('[data-radix-dialog-close]')` returned null because no `<Dialog.Close>` element existed
+- [x] **Solution**: Created `useDialogState` hook using TanStack DB local-only collection for UI state
+- [x] **Files fixed**:
+  - `src/hooks/useDialogState.ts` - New hook for controlled dialog state
+  - `src/db/collections.ts` - Added `uiStateCollection` for dialog open/close state
+  - `src/routes/golfers/$golferId.tsx` - Edit golfer dialog
+  - `src/routes/golfers/index.tsx` - Add golfer dialog
+  - `src/routes/trips/$tripId/teams.tsx` - Create team dialog
+  - `src/routes/trips/$tripId/challenges.tsx` - All challenge dialogs
+
 ---
 
 ## Completed - Phase 1: Foundation
@@ -61,12 +82,12 @@
 
 ---
 
-## TODO - Phase 5: Challenges
+## Completed - Phase 5: Challenges
 
-- [ ] Challenge creation form (KP, longest drive, custom)
-- [ ] Result entry for manual challenges
-- [ ] Auto-calculated challenge results (most birdies, best net)
-- [ ] Winner display and history
+- [x] Challenge creation form (KP, longest drive, custom)
+- [x] Result entry for manual challenges
+- [x] Auto-calculated challenge results (most birdies, best net)
+- [x] Winner display and history
 
 ## TODO - Phase 6: Polish
 
@@ -96,6 +117,10 @@ src/
 │   ├── DataLoader.tsx          # Auto-seeds data
 │   ├── Header.tsx              # Navigation
 │   ├── ThemePicker.tsx         # Font themes
+│   ├── challenges/
+│   │   ├── ChallengeCard.tsx   # Challenge display component
+│   │   ├── ChallengeForm.tsx   # Create/edit challenge
+│   │   └── ChallengeResultEntry.tsx  # Enter manual results
 │   ├── golfers/
 │   │   ├── GolferCard.tsx
 │   │   └── GolferForm.tsx
@@ -114,20 +139,25 @@ src/
 ├── contexts/
 │   └── ThemeContext.tsx
 ├── db/
-│   ├── collections.ts          # TanStack DB schemas
+│   ├── collections.ts          # TanStack DB schemas + uiStateCollection
 │   └── seed.ts                 # Sample data
+├── hooks/
+│   └── useDialogState.ts       # Controlled dialog state via TanStack DB
 ├── lib/
+│   ├── challenges.ts           # Challenge utilities (distance parsing, etc.)
 │   └── scoring.ts              # Golf scoring logic
 └── routes/
     ├── __root.tsx
     ├── index.tsx               # Home
     ├── golfers/
-    │   └── index.tsx           # Golfer directory
+    │   ├── index.tsx           # Golfer directory
+    │   └── $golferId.tsx       # Golfer detail
     └── trips/
         ├── index.tsx           # Trip list
         ├── new.tsx             # Create trip
         └── $tripId/
             ├── index.tsx       # Trip dashboard
+            ├── challenges.tsx  # Challenges management
             ├── golfers.tsx     # Manage participants
             ├── leaderboards.tsx
             ├── teams.tsx


### PR DESCRIPTION
## Summary

- **Phase 5: Challenges** - Complete implementation of golf challenges feature (KP, Longest Drive, Most Birdies, etc.)
- **Bug Fix** - Fixed dialog not closing after save by replacing hacky `querySelector` approach with controlled state via TanStack DB

## Changes

### New Files
- `src/lib/challenges.ts` - Utility functions for KP distance parsing/formatting, winner determination, type labels
- `src/components/challenges/ChallengeCard.tsx` - Display component with type badge, scope context, winner display
- `src/components/challenges/ChallengeForm.tsx` - Create/edit dialog with type selector, scope settings, round/hole selectors
- `src/components/challenges/ChallengeResultEntry.tsx` - Manual result entry with golfer list, distance inputs
- `src/routes/trips/$tripId/challenges.tsx` - Main challenges page with active/completed sections
- `src/hooks/useDialogState.ts` - Hook for controlled dialog state using TanStack DB

### Modified Files
- `src/db/collections.ts` - Added `uiStateCollection` for dialog UI state
- `src/routes/trips/$tripId/index.tsx` - Added Challenges link with Target icon
- `src/routes/golfers/$golferId.tsx` - Fixed edit golfer dialog
- `src/routes/golfers/index.tsx` - Fixed add golfer dialog
- `src/routes/trips/$tripId/teams.tsx` - Fixed create team dialog

## Test plan

- [ ] Navigate to a trip → click "Challenges" in the Manage grid
- [ ] Create a KP challenge for a par 3 hole
- [ ] Enter results with distances (e.g., "4'6\"")
- [ ] Verify winner is auto-selected (lowest distance)
- [ ] Create a "Most Birdies" challenge (auto-calculated)
- [ ] Edit a golfer → verify dialog closes after save
- [ ] Add a new golfer → verify dialog closes after save

This pull request was AI-assisted by Isaac.