### PR TITLE
Add navigation improvements for golfer rounds and leaderboards

### DIFF
--- a/src/components/leaderboards/LeaderboardTable.tsx
+++ b/src/components/leaderboards/LeaderboardTable.tsx
@@ -1,4 +1,5 @@
 import { Table, Text, Badge, Flex, Avatar } from '@radix-ui/themes'
+import { Link } from '@tanstack/react-router'
 import { Trophy } from 'lucide-react'
 
 export interface LeaderboardEntry {
@@ -65,17 +66,26 @@ export function LeaderboardTable({
               )}
             </Table.Cell>
             <Table.Cell>
-              <Flex align="center" gap="2">
-                <Avatar
-                  size="1"
-                  fallback={getInitials(entry.name)}
-                  radius="full"
-                  color={entry.rank === 1 ? 'amber' : undefined}
-                />
-                <Text weight={entry.rank <= highlightTop ? 'medium' : 'regular'}>
-                  {entry.name}
-                </Text>
-              </Flex>
+              <Link
+                to="/golfers/$golferId"
+                params={{ golferId: entry.golferId }}
+                style={{ textDecoration: 'none' }}
+              >
+                <Flex align="center" gap="2">
+                  <Avatar
+                    size="1"
+                    fallback={getInitials(entry.name)}
+                    radius="full"
+                    color={entry.rank === 1 ? 'amber' : undefined}
+                  />
+                  <Text
+                    weight={entry.rank <= highlightTop ? 'medium' : 'regular'}
+                    className="golfer-link"
+                  >
+                    {entry.name}
+                  </Text>
+                </Flex>
+              </Link>
             </Table.Cell>
             {showRounds && (
               <Table.Cell>

--- a/src/routes/golfers/$golferId.tsx
+++ b/src/routes/golfers/$golferId.tsx
@@ -12,7 +12,7 @@ import {
   Separator,
   Grid,
 } from '@radix-ui/themes'
-import { ArrowLeft, Mail, Phone, Trophy, Flag, Calendar, Edit } from 'lucide-react'
+import { ArrowLeft, Mail, Phone, Trophy, Flag, Calendar, Edit, ChevronRight } from 'lucide-react'
 import { useLiveQuery, eq } from '@tanstack/react-db'
 import {
   golferCollection,
@@ -20,6 +20,7 @@ import {
   tripCollection,
   roundSummaryCollection,
   roundCollection,
+  courseCollection,
 } from '../../db/collections'
 import { GolferForm } from '../../components/golfers/GolferForm'
 
@@ -66,19 +67,26 @@ function GolferDetailPage() {
     [golferId]
   )
 
-  // Get round summaries for this golfer
+  // Get round summaries for this golfer with trip and course info
   const { data: roundSummaries } = useLiveQuery(
     (q) =>
       q
         .from({ rs: roundSummaryCollection })
         .where(({ rs }) => eq(rs.golferId, golferId))
         .join({ round: roundCollection }, ({ rs, round }) => eq(rs.roundId, round!.id))
-        .select(({ rs, round }) => ({
+        .join({ trip: tripCollection }, ({ round, trip }) => eq(round!.tripId, trip!.id))
+        .join({ course: courseCollection }, ({ round, course }) => eq(round!.courseId, course!.id))
+        .select(({ rs, round, trip, course }) => ({
           roundId: rs.roundId,
+          tripId: round!.tripId,
+          tripName: trip!.name,
+          courseId: round!.courseId,
+          courseName: course!.name,
           totalGross: rs.totalGross,
           totalNet: rs.totalNet,
           totalStableford: rs.totalStableford,
           birdiesOrBetter: rs.birdiesOrBetter,
+          kps: rs.kps,
           roundDate: round!.roundDate,
           roundNumber: round!.roundNumber,
         }))
@@ -321,37 +329,66 @@ function GolferDetailPage() {
 
             <Flex direction="column" gap="2">
               {rounds.slice(0, 5).map((round) => (
-                <Card key={round.roundId}>
-                  <Flex justify="between" align="center">
-                    <Flex direction="column" gap="3">
-                      <Text size="2" color="gray">
-                        {round.roundDate.toLocaleDateString('en-US', {
-                          month: 'short',
-                          day: 'numeric',
-                          year: 'numeric',
-                        })}
-                      </Text>
-                      <Flex gap="4">
-                        <Text size="2">
-                          <span style={{ color: 'var(--gray-11)' }}>Gross:</span> {round.totalGross}
-                        </Text>
-                        <Text size="2">
-                          <span style={{ color: 'var(--gray-11)' }}>Net:</span> {round.totalNet}
-                        </Text>
+                <Link
+                  key={round.roundId}
+                  to="/trips/$tripId/rounds/$roundId/scorecard"
+                  params={{ tripId: round.tripId, roundId: round.roundId }}
+                  search={{ golferId }}
+                  style={{ textDecoration: 'none' }}
+                >
+                  <Card>
+                    <Flex justify="between" align="center">
+                      <Flex direction="column" gap="3">
+                        <Flex align="center" gap="2">
+                          <Badge variant="soft">Round {round.roundNumber}</Badge>
+                          <Text weight="medium">{round.courseName}</Text>
+                        </Flex>
+                        <Flex align="center" gap="3" wrap="wrap">
+                          <Flex align="center" gap="1">
+                            <Calendar size={12} />
+                            <Text size="1" color="gray">
+                              {round.roundDate.toLocaleDateString('en-US', {
+                                month: 'short',
+                                day: 'numeric',
+                                year: 'numeric',
+                              })}
+                            </Text>
+                          </Flex>
+                          <Flex align="center" gap="1">
+                            <Flag size={12} />
+                            <Text size="1" color="gray">
+                              {round.tripName}
+                            </Text>
+                          </Flex>
+                        </Flex>
+                        <Flex gap="4">
+                          <Text size="2">
+                            <span style={{ color: 'var(--gray-11)' }}>Gross:</span> {round.totalGross}
+                          </Text>
+                          <Text size="2">
+                            <span style={{ color: 'var(--gray-11)' }}>Net:</span> {round.totalNet}
+                          </Text>
+                          {round.birdiesOrBetter > 0 && (
+                            <Text size="2" color="grass">
+                              {round.birdiesOrBetter} birdies
+                            </Text>
+                          )}
+                          {round.kps > 0 && (
+                            <Text size="2" color="blue">
+                              {round.kps} KP{round.kps > 1 ? 's' : ''}
+                            </Text>
+                          )}
+                        </Flex>
+                      </Flex>
+                      <Flex align="center" gap="2">
+                        <Badge color="amber" size="2">
+                          {round.totalStableford} pts
+                        </Badge>
+                        <ChevronRight size={16} style={{ color: 'var(--gray-9)' }} />
                       </Flex>
                     </Flex>
-                    <Flex direction="column" align="end" gap="1">
-                      <Badge color="amber" size="2">
-                        {round.totalStableford} pts
-                      </Badge>
-                      {round.birdiesOrBetter > 0 && (
-                        <Text size="1" color="grass">
-                          {round.birdiesOrBetter} birdies+
-                        </Text>
-                      )}
-                    </Flex>
-                  </Flex>
-                </Card>
+                  </Card>
+                </Link>
               ))}
             </Flex>
           </Flex>

--- a/src/styles.css
+++ b/src/styles.css
@@ -141,6 +141,15 @@ body {
   color: var(--amber-7);
 }
 
+/* Golfer link hover in leaderboards */
+.golfer-link {
+  transition: color 0.15s ease;
+}
+
+.golfer-link:hover {
+  color: var(--amber-9);
+}
+
 /* Fix capsize text overlap on large headings */
 .rt-Heading.rt-r-size-8,
 .rt-Heading.rt-r-size-9 {


### PR DESCRIPTION
## Summary

Improves navigation between related views:
1. **Golfer page recent rounds** → click to go to their scorecard
2. **Leaderboard golfer names** → click to go to golfer detail page

## Changes

### Golfer Page Recent Rounds (`src/routes/golfers/$golferId.tsx`)
- Expanded round query to include `tripId`, `tripName`, `courseId`, `courseName`, `kps`
- Made round cards clickable with `Link` to scorecard page
- Added more context: course name, round number badge, trip name, date
- Display additional stats: birdies count, KPs count
- Added `ChevronRight` icon to indicate clickable

### Leaderboard Table (`src/components/leaderboards/LeaderboardTable.tsx`)
- Wrapped golfer names with `Link` to `/golfers/$golferId`
- Added hover effect with gold color transition

### Styles (`src/styles.css`)
- Added `.golfer-link` hover style

## Test plan

- [ ] Go to a golfer's page (Golfers → click a golfer)
- [ ] Click on a recent round → should navigate to their scorecard
- [ ] Go to a trip's leaderboard
- [ ] Click on a golfer's name → should navigate to their golfer detail page

This pull request was AI-assisted by Isaac.