### PR TITLE
Fix trip-specific handicap system

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -67,7 +67,11 @@
       "Bash(pnpm test:unit:*)",
       "Bash(pnpm test:coverage:*)",
       "Bash(jj branch rename:*)",
-      "Bash(jj bookmark rename:*)"
+      "Bash(jj bookmark rename:*)",
+      "Bash(jj bookmark delete:*)",
+      "Bash(pnpm exec vitest:*)",
+      "mcp__plugin_chrome-devtools-mcp_chrome-devtools__press_key",
+      "mcp__plugin_chrome-devtools-mcp_chrome-devtools__fill"
     ]
   },
   "enabledPlugins": {

--- a/src/components/golfers/GolferForm.tsx
+++ b/src/components/golfers/GolferForm.tsx
@@ -58,17 +58,37 @@ export function GolferForm({ initialData, golferId, onSuccess }: GolferFormProps
 
     if (isEditing && golferId) {
       golferCollection.update(golferId, (draft) => {
+        const oldHandicap = draft.handicap
         draft.name = result.data.name
         draft.email = result.data.email
         draft.phone = result.data.phone
         draft.handicap = result.data.handicap
+
+        // Track handicap changes in history
+        if (oldHandicap !== result.data.handicap) {
+          const history = draft.handicapHistory || []
+          history.push({
+            handicap: result.data.handicap,
+            date: new Date(),
+            source: 'manual' as const,
+          })
+          draft.handicapHistory = history
+        }
       })
     } else {
+      const now = new Date()
       golferCollection.insert({
         id: crypto.randomUUID(),
         ...result.data,
+        handicapHistory: [
+          {
+            handicap: result.data.handicap,
+            date: now,
+            source: 'manual' as const,
+          },
+        ],
         profileImageUrl: null,
-        createdAt: new Date(),
+        createdAt: now,
       })
     }
 

--- a/src/db/collections.ts
+++ b/src/db/collections.ts
@@ -30,12 +30,20 @@ export const tripSchema = z.object({
   createdAt: dateField,
 })
 
+// Handicap history entry for tracking changes over time
+export const handicapHistoryEntrySchema = z.object({
+  handicap: z.number(),
+  date: dateField,
+  source: z.enum(['manual', 'ghin', 'import']).default('manual'),
+})
+
 export const golferSchema = z.object({
   id: z.string(),
   name: z.string(),
   email: z.string().default(''),
   phone: z.string().default(''),
-  handicap: z.number().default(0),
+  handicap: z.number().default(0), // Current handicap
+  handicapHistory: z.array(handicapHistoryEntrySchema).default([]), // Timestamped history
   profileImageUrl: z.string().nullable().default(null),
   createdAt: dateField,
 })
@@ -185,6 +193,7 @@ export const formErrorSchema = z.object({
 // ============================================================================
 
 export type Trip = z.output<typeof tripSchema>
+export type HandicapHistoryEntry = z.output<typeof handicapHistoryEntrySchema>
 export type Golfer = z.output<typeof golferSchema>
 export type TripGolfer = z.output<typeof tripGolferSchema>
 export type Course = z.output<typeof courseSchema>

--- a/src/db/seed.ts
+++ b/src/db/seed.ts
@@ -219,14 +219,21 @@ export function seedData() {
       email: '',
       phone: '',
       handicap: g.handicap,
+      handicapHistory: [
+        {
+          handicap: g.handicap,
+          date: now,
+          source: 'manual' as const,
+        },
+      ],
       profileImageUrl: null,
       createdAt: now,
     }
   })
   golferCollection.insert(golfers)
 
-  // Create trip golfers
-  const tripGolfers: TripGolfer[] = golferIds.map((golferId) => ({
+  // Create trip golfers with captured handicap
+  const tripGolfers: TripGolfer[] = golferIds.map((golferId, idx) => ({
     id: generateId(),
     tripId,
     golferId,
@@ -234,6 +241,7 @@ export function seedData() {
     invitedAt: now,
     acceptedAt: now,
     includedInScoring: true,
+    handicapOverride: golferData[idx].handicap, // Capture handicap at time of trip
   }))
   tripGolferCollection.insert(tripGolfers)
 

--- a/src/routes/golfers/$golferId.tsx
+++ b/src/routes/golfers/$golferId.tsx
@@ -12,7 +12,7 @@ import {
   Separator,
   Grid,
 } from '@radix-ui/themes'
-import { ArrowLeft, Mail, Phone, Trophy, Flag, Calendar, Edit, ChevronRight } from 'lucide-react'
+import { ArrowLeft, Mail, Phone, Trophy, Flag, Calendar, Edit, ChevronRight, History } from 'lucide-react'
 import { useLiveQuery, eq } from '@tanstack/react-db'
 import { useDialogState } from '../../hooks/useDialogState'
 import {
@@ -201,6 +201,33 @@ function GolferDetailPage() {
             </Flex>
           </Flex>
         </Card>
+
+        {/* Handicap history */}
+        {golfer.handicapHistory && golfer.handicapHistory.length > 0 && (
+          <Card>
+            <Flex direction="column" gap="3">
+              <Flex align="center" gap="2">
+                <History size={16} style={{ color: 'var(--gray-9)' }} />
+                <Text size="2" weight="medium">Handicap History</Text>
+              </Flex>
+              <Flex gap="3" wrap="wrap">
+                {golfer.handicapHistory
+                  .slice()
+                  .reverse()
+                  .slice(0, 5)
+                  .map((entry, idx) => (
+                    <Badge
+                      key={idx}
+                      variant={idx === 0 ? 'solid' : 'soft'}
+                      color={idx === 0 ? 'grass' : 'gray'}
+                    >
+                      {entry.handicap.toFixed(1)} ({entry.date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: '2-digit' })})
+                    </Badge>
+                  ))}
+              </Flex>
+            </Flex>
+          </Card>
+        )}
 
         {/* Stats summary */}
         {totalRounds > 0 && (

--- a/src/routes/trips/$tripId/golfers.tsx
+++ b/src/routes/trips/$tripId/golfers.tsx
@@ -62,6 +62,12 @@ function TripGolfersPage() {
     if (existing) {
       tripGolferCollection.delete(existing.id)
     } else {
+      // Capture the golfer's current handicap when adding them to the trip
+      // This ensures the trip uses a locked-in handicap that won't change
+      // if the golfer's main handicap is updated later
+      const golfer = allGolfers?.find((g) => g.id === golferId)
+      const capturedHandicap = golfer?.handicap ?? 0
+
       tripGolferCollection.insert({
         id: crypto.randomUUID(),
         tripId,
@@ -69,7 +75,7 @@ function TripGolfersPage() {
         status: 'accepted',
         invitedAt: new Date(),
         acceptedAt: new Date(),
-        handicapOverride: null,
+        handicapOverride: capturedHandicap,
       })
     }
   }
@@ -86,18 +92,10 @@ function TripGolfersPage() {
   function saveHandicapOverride(tripGolferId: string) {
     const value = parseFloat(handicapValue)
     if (!isNaN(value) && value >= 0 && value <= 54) {
-      tripGolferCollection.update(tripGolferId, {
-        handicapOverride: value,
+      tripGolferCollection.update(tripGolferId, (draft) => {
+        draft.handicapOverride = value
       })
     }
-    setEditingHandicap(null)
-    setHandicapValue('')
-  }
-
-  function clearHandicapOverride(tripGolferId: string) {
-    tripGolferCollection.update(tripGolferId, {
-      handicapOverride: null,
-    })
     setEditingHandicap(null)
     setHandicapValue('')
   }
@@ -153,7 +151,10 @@ function TripGolfersPage() {
                   tripGolfer?.handicapOverride !== null
                     ? tripGolfer?.handicapOverride
                     : golfer.handicap
-                const hasOverride = tripGolfer?.handicapOverride !== null
+
+                const isOverrideDifferent =
+                  tripGolfer?.handicapOverride !== null &&
+                  tripGolfer?.handicapOverride !== golfer.handicap
 
                 return (
                   <Card key={golfer.id}>
@@ -164,7 +165,7 @@ function TripGolfersPage() {
                       />
                       <Flex style={{ flex: 1 }} align="center" justify="between">
                         <GolferCard golfer={golfer} />
-                        <Flex align="center" gap="2">
+                        <Flex direction="column" align="end" gap="1">
                           {editingHandicap === tripGolfer?.id ? (
                             <Flex align="center" gap="1">
                               <TextField.Root
@@ -197,36 +198,37 @@ function TripGolfersPage() {
                           ) : (
                             <Flex align="center" gap="1">
                               <Tooltip
-                                content={
-                                  hasOverride
-                                    ? `Trip handicap (base: ${golfer.handicap})`
-                                    : 'Click to set trip-specific handicap'
-                                }
+                                content={`Trip handicap used for scoring. Current: ${golfer.handicap.toFixed(1)}`}
                               >
                                 <Badge
-                                  color={hasOverride ? 'amber' : 'gray'}
-                                  variant={hasOverride ? 'solid' : 'soft'}
+                                  color="grass"
+                                  variant="solid"
                                   style={{ cursor: 'pointer' }}
                                   onClick={() =>
                                     startEditingHandicap(tripGolfer!, golfer.handicap)
                                   }
                                 >
-                                  {effectiveHandicap}
+                                  HCP {effectiveHandicap?.toFixed(1)}
                                 </Badge>
                               </Tooltip>
-                              {hasOverride && (
-                                <Tooltip content="Reset to golfer's default handicap">
-                                  <IconButton
-                                    size="1"
-                                    variant="ghost"
-                                    color="gray"
-                                    onClick={() => clearHandicapOverride(tripGolfer!.id)}
-                                  >
-                                    <X size={12} />
-                                  </IconButton>
-                                </Tooltip>
-                              )}
+                              <Tooltip content="Edit trip handicap">
+                                <IconButton
+                                  size="1"
+                                  variant="ghost"
+                                  color="gray"
+                                  onClick={() =>
+                                    startEditingHandicap(tripGolfer!, golfer.handicap)
+                                  }
+                                >
+                                  <Edit2 size={12} />
+                                </IconButton>
+                              </Tooltip>
                             </Flex>
+                          )}
+                          {isOverrideDifferent && (
+                            <Text size="1" color="gray">
+                              Current: {golfer.handicap.toFixed(1)}
+                            </Text>
                           )}
                         </Flex>
                       </Flex>

--- a/src/routes/trips/$tripId/rounds/new.tsx
+++ b/src/routes/trips/$tripId/rounds/new.tsx
@@ -10,7 +10,7 @@ import {
   Select,
   Dialog,
 } from '@radix-ui/themes'
-import { ChevronLeft, Plus, Search } from 'lucide-react'
+import { ChevronLeft, Search } from 'lucide-react'
 import { useState } from 'react'
 import { useLiveQuery, eq } from '@tanstack/react-db'
 import {

--- a/tests/fixtures/factories.ts
+++ b/tests/fixtures/factories.ts
@@ -56,13 +56,18 @@ export function createGolfer(
     email: string
     phone: string
     handicap: number
+    handicapHistory: Array<{ handicap: number; date: Date; source: 'manual' | 'ghin' | 'import' }>
   }> = {}
 ) {
+  const handicap = overrides.handicap ?? 15
   return {
     name: overrides.name ?? 'Test Golfer',
     email: overrides.email ?? 'test@example.com',
     phone: overrides.phone ?? '555-1234',
-    handicap: overrides.handicap ?? 15,
+    handicap,
+    handicapHistory: overrides.handicapHistory ?? [
+      { handicap, date: new Date(), source: 'manual' as const },
+    ],
   }
 }
 

--- a/tests/unit/lib/validation.test.ts
+++ b/tests/unit/lib/validation.test.ts
@@ -314,7 +314,13 @@ describe('validateForm', () => {
       const result = validateForm(golferFormSchema, golfer)
       expect(result.success).toBe(true)
       if (result.success) {
-        expect(result.data).toEqual(golfer)
+        // Only compare fields that the form schema validates
+        expect(result.data).toEqual({
+          name: golfer.name,
+          email: golfer.email,
+          phone: golfer.phone,
+          handicap: golfer.handicap,
+        })
       }
     })
   })


### PR DESCRIPTION
## Summary
- Fix TanStack DB update calls to use callback pattern `(draft) => { draft.field = value }`
- Auto-capture golfer's handicap when adding to trip (locks in the value)
- Add `handicapHistory` array to golfer schema for timestamped tracking
- Show "Current: X.X" when trip handicap differs from golfer's current handicap

## Test plan
- [x] Unit tests pass (148 tests)
- [x] Verified handicap editing works in browser via Chrome DevTools
- [x] Trip handicap displays correctly and updates independently

This pull request was AI-assisted by Isaac.