### PR TITLE
fix: score entry bugs - backspace and gross totals

### DIFF
--- a/src/components/scoring/ScoreEntry.tsx
+++ b/src/components/scoring/ScoreEntry.tsx
@@ -7,7 +7,7 @@ interface ScoreEntryProps {
 	handicapStrokes: number;
 	netScore: number | null;
 	stablefordPoints: number | null;
-	onChange: (grossScore: number) => void;
+	onChange: (grossScore: number | null) => void;
 	compact?: boolean;
 	readOnly?: boolean;
 }
@@ -55,9 +55,14 @@ export function ScoreEntry({
 					max="15"
 					value={grossScore ?? ""}
 					onChange={(e) => {
-						const val = parseInt(e.target.value);
-						if (!isNaN(val) && val >= 1) {
-							onChange(val);
+						const value = e.target.value;
+						if (value === "") {
+							onChange(null);
+						} else {
+							const val = parseInt(value, 10);
+							if (!isNaN(val) && val >= 1) {
+								onChange(val);
+							}
 						}
 					}}
 					style={{ width: "40px", textAlign: "center" }}
@@ -115,9 +120,14 @@ export function ScoreEntry({
 					max="15"
 					value={grossScore ?? ""}
 					onChange={(e) => {
-						const val = parseInt(e.target.value);
-						if (!isNaN(val) && val >= 1) {
-							onChange(val);
+						const value = e.target.value;
+						if (value === "") {
+							onChange(null);
+						} else {
+							const val = parseInt(value, 10);
+							if (!isNaN(val) && val >= 1) {
+								onChange(val);
+							}
 						}
 					}}
 					style={{ width: "56px", textAlign: "center" }}

--- a/src/components/scoring/Scorecard.tsx
+++ b/src/components/scoring/Scorecard.tsx
@@ -23,7 +23,7 @@ interface ScorecardProps {
 	slopeRating: number | null;
 	coursePar: number;
 	scores: HoleScore[];
-	onScoreChange: (holeId: string, grossScore: number) => void;
+	onScoreChange: (holeId: string, grossScore: number | null) => void;
 	handicapOverride?: number | null; // Trip-level handicap override
 	readOnly?: boolean; // Disable score editing
 }

--- a/src/routes/trips/$tripId/rounds/$roundId/scorecard.tsx
+++ b/src/routes/trips/$tripId/rounds/$roundId/scorecard.tsx
@@ -29,6 +29,7 @@ import {
 	useCourse,
 	useCreateRoundSummary,
 	useCreateScore,
+	useDeleteScore,
 	useGolfers,
 	useHolesByCourseId,
 	useRound,
@@ -82,6 +83,7 @@ function ScorecardPage() {
 	// Mutations
 	const createScore = useCreateScore();
 	const updateScore = useUpdateScore();
+	const deleteScoreMutation = useDeleteScore();
 	const createRoundSummary = useCreateRoundSummary();
 	const updateRoundSummaryMutation = useUpdateRoundSummary();
 
@@ -210,11 +212,26 @@ function ScorecardPage() {
 	]);
 
 	const handleScoreChange = useCallback(
-		(holeId: string, grossScore: number) => {
+		(holeId: string, grossScore: number | null) => {
 			if (!golfer || !holes || !course) return;
 
 			const hole = holes.find((h: Hole) => h.id === holeId);
 			if (!hole) return;
+
+			const existingScore = scores.find((s: Score) => s.holeId === holeId);
+
+			// Handle score deletion
+			if (grossScore === null) {
+				if (existingScore) {
+					deleteScoreMutation.mutate(
+						{ id: existingScore.id, roundId },
+						{
+							onSuccess: () => updateRoundSummaryFn(),
+						},
+					);
+				}
+				return;
+			}
 
 			// Use trip handicap override if set
 			const tripGolfer = tripGolferMap.get(golferId);
@@ -233,8 +250,6 @@ function ScorecardPage() {
 			);
 			const netScore = calculateNetScore(grossScore, handicapStrokes);
 			const stablefordPoints = calculateStablefordPoints(netScore, hole.par);
-
-			const existingScore = scores.find((s: Score) => s.holeId === holeId);
 
 			if (existingScore) {
 				updateScore.mutate(
@@ -280,6 +295,7 @@ function ScorecardPage() {
 			tripGolferMap,
 			updateScore,
 			createScore,
+			deleteScoreMutation,
 			updateRoundSummaryFn,
 		],
 	);


### PR DESCRIPTION
## Summary
- Allow backspace to clear score by handling null values (#18)
- Delete score record when clearing instead of setting to 0
- Fix gross totals by properly removing deleted scores (#20)

## Test plan
- [ ] Enter score, then backspace to clear → should clear completely
- [ ] Enter scores for 9 holes, clear one → gross total should update correctly
- [ ] Rapidly enter/clear scores → totals should stay accurate

Closes #18, closes #20

This pull request and its description were written by Isaac.