### PR TITLE
feat: add tee box selection to rounds

### DIFF
--- a/src/db/collections.ts
+++ b/src/db/collections.ts
@@ -88,6 +88,7 @@ export const roundSchema = z.object({
 	id: z.string(),
 	tripId: z.string(),
 	courseId: z.string(),
+	teeBoxId: z.string().nullable().default(null),
 	roundDate: dateField,
 	roundNumber: z.number().default(1),
 	notes: z.string().default(""),

--- a/src/db/drizzle/migrations/0003_add_tee_box_to_rounds.sql
+++ b/src/db/drizzle/migrations/0003_add_tee_box_to_rounds.sql
@@ -1,0 +1,5 @@
+-- Add tee_box_id column to rounds table
+ALTER TABLE rounds ADD COLUMN tee_box_id UUID REFERENCES tee_boxes(id) ON DELETE SET NULL;
+
+-- Create index for faster lookups
+CREATE INDEX IF NOT EXISTS idx_rounds_tee_box_id ON rounds(tee_box_id);

--- a/src/db/drizzle/schema.ts
+++ b/src/db/drizzle/schema.ts
@@ -134,6 +134,9 @@ export const rounds = pgTable("rounds", {
 	courseId: uuid("course_id")
 		.notNull()
 		.references(() => courses.id, { onDelete: "cascade" }),
+	teeBoxId: uuid("tee_box_id").references(() => teeBoxes.id, {
+		onDelete: "set null",
+	}),
 	roundDate: timestamp("round_date", { withTimezone: true }).notNull(),
 	roundNumber: integer("round_number").notNull().default(1),
 	notes: text("notes").notNull().default(""),

--- a/src/routes/trips/$tripId/rounds/new.tsx
+++ b/src/routes/trips/$tripId/rounds/new.tsx
@@ -17,6 +17,7 @@ import {
 	useCourses,
 	useCreateRound,
 	useRoundsByTripId,
+	useTeeBoxesByCourseId,
 	useTrip,
 } from "../../../../hooks/queries";
 import { useTripRole } from "../../../../hooks/useTripRole";
@@ -31,6 +32,7 @@ function NewRoundPage() {
 	const navigate = useNavigate();
 	const [addCourseDialogOpen, setAddCourseDialogOpen] = useState(false);
 	const [selectedCourseId, setSelectedCourseId] = useState<string>("");
+	const [selectedTeeBoxId, setSelectedTeeBoxId] = useState<string>("");
 	const { canManage, isLoading: roleLoading } = useTripRole(tripId);
 
 	// Redirect non-organizers (only after role is loaded)
@@ -43,7 +45,13 @@ function NewRoundPage() {
 	const { data: trip } = useTrip(tripId);
 	const { data: courses } = useCourses();
 	const { data: existingRounds } = useRoundsByTripId(tripId);
+	const { data: teeBoxes } = useTeeBoxesByCourseId(selectedCourseId);
 	const createRound = useCreateRound();
+
+	// Reset tee box selection when course changes
+	useEffect(() => {
+		setSelectedTeeBoxId("");
+	}, [selectedCourseId]);
 
 	const sortedCourses = courses
 		?.slice()
@@ -68,6 +76,7 @@ function NewRoundPage() {
 				id: roundId,
 				tripId,
 				courseId: selectedCourseId,
+				teeBoxId: selectedTeeBoxId || null,
 				roundDate,
 				roundNumber: nextRoundNumber,
 				notes,
@@ -169,6 +178,33 @@ function NewRoundPage() {
 								</Text>
 							)}
 						</Flex>
+
+						{/* Tee Box Selection - only show when course has tee boxes */}
+						{selectedCourseId && teeBoxes && teeBoxes.length > 0 && (
+							<Flex direction="column" gap="1">
+								<Text as="label" size="2" weight="medium">
+									Tee Box (optional)
+								</Text>
+								<Select.Root
+									value={selectedTeeBoxId}
+									onValueChange={setSelectedTeeBoxId}
+								>
+									<Select.Trigger placeholder="Select a tee box" />
+									<Select.Content>
+										{teeBoxes.map((teeBox) => (
+											<Select.Item key={teeBox.id} value={teeBox.id}>
+												{teeBox.teeName} ({teeBox.gender === "male" ? "M" : "F"}{" "}
+												- {teeBox.totalYards} yds, CR {teeBox.courseRating}/
+												{teeBox.slopeRating})
+											</Select.Item>
+										))}
+									</Select.Content>
+								</Select.Root>
+								<Text size="1" color="gray">
+									Used for handicap calculations. Can be changed later.
+								</Text>
+							</Flex>
+						)}
 
 						<Flex direction="column" gap="1">
 							<Text as="label" size="2" weight="medium" htmlFor="roundDate">


### PR DESCRIPTION
## Summary
- Added tee_box_id column to rounds table with migration
- Updated Drizzle schema and Zod collections
- Added tee box selector UI in new round form
- Tee box options filter based on selected course

Closes #21

## Test plan
- [ ] Create a new round → should see tee box dropdown after selecting course
- [ ] Select different courses → tee boxes should update
- [ ] Create round with tee box selected → should save correctly
- [ ] Create round without tee box → should work (nullable)

This pull request and its description were written by Isaac.