### PR TITLE
feat: manual round reordering

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -148,7 +148,11 @@
       "Bash(vercel link:*)",
       "Bash(vercel env add:*)",
       "Bash(vercel env:*)",
-      "Bash(vercel:*)"
+      "Bash(vercel:*)",
+      "Bash(xargs ls:*)",
+      "Bash(jj absorb:*)",
+      "Bash(jj resolve:*)",
+      "Bash(agent-browser:*)"
     ]
   },
   "enabledPlugins": {

--- a/src/components/trips/QuickActions.tsx
+++ b/src/components/trips/QuickActions.tsx
@@ -17,7 +17,7 @@ export function QuickActions({ tripId, canManage }: QuickActionsProps) {
 				<Link to="/trips/$tripId/rounds/new" params={{ tripId }}>
 					<Button variant="solid" size="3" style={{ width: "100%" }}>
 						<Plus size={18} />
-						Add Round
+						Add Course
 					</Button>
 				</Link>
 			)}

--- a/src/hooks/queries/useRounds.ts
+++ b/src/hooks/queries/useRounds.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type { Round } from "../../db/collections";
-import { deleteRound, insertRound, updateRound } from "../../server/mutations";
+import { deleteRound, insertRound, reorderRounds, updateRound } from "../../server/mutations";
 import { getRound, getRounds, getRoundsByTripId } from "../../server/queries";
 import { tripKeys } from "./useTrips";
 
@@ -78,6 +78,17 @@ export function useDeleteRound() {
 			deleteRound({ data: { id } }),
 		onSuccess: (_, { tripId }) => {
 			queryClient.invalidateQueries({ queryKey: roundKeys.lists() });
+			queryClient.invalidateQueries({ queryKey: roundKeys.byTrip(tripId) });
+		},
+	});
+}
+
+export function useReorderRounds() {
+	const queryClient = useQueryClient();
+	return useMutation({
+		mutationFn: ({ tripId, roundIds }: { tripId: string; roundIds: string[] }) =>
+			reorderRounds({ data: { tripId, roundIds } }),
+		onSuccess: (_, { tripId }) => {
 			queryClient.invalidateQueries({ queryKey: roundKeys.byTrip(tripId) });
 		},
 	});

--- a/src/routes/trips/$tripId/challenges.tsx
+++ b/src/routes/trips/$tripId/challenges.tsx
@@ -8,8 +8,8 @@ import {
 	Heading,
 	Text,
 } from "@radix-ui/themes";
-import { createFileRoute } from "@tanstack/react-router";
-import { Globe, Plus } from "lucide-react";
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { ArrowLeft, Globe, Plus } from "lucide-react";
 import { useEffect, useMemo, useRef } from "react";
 import { ChallengeCard } from "../../../components/challenges/ChallengeCard";
 import { ChallengeForm } from "../../../components/challenges/ChallengeForm";
@@ -284,6 +284,12 @@ function ChallengesPage() {
 	return (
 		<Container size="2" py="6">
 			<Flex direction="column" gap="5">
+				<Link to="/trips/$tripId" params={{ tripId }}>
+					<Button variant="ghost" size="1">
+						<ArrowLeft size={16} />
+						Back to Trip
+					</Button>
+				</Link>
 				<Flex justify="between" align="center">
 					<Flex direction="column" gap="3">
 						<Heading size="7">Challenges</Heading>

--- a/src/routes/trips/$tripId/rounds/index.tsx
+++ b/src/routes/trips/$tripId/rounds/index.tsx
@@ -5,14 +5,17 @@ import {
 	Container,
 	Flex,
 	Heading,
+	IconButton,
 	Text,
 } from "@radix-ui/themes";
 import { createFileRoute, Link } from "@tanstack/react-router";
-import { ChevronRight, Plus } from "lucide-react";
+import { ArrowLeft, ChevronDown, ChevronRight, ChevronUp, GripVertical, Pencil, Plus, X } from "lucide-react";
+import { useState } from "react";
 import { RoundDeleteButton } from "../../../../components/rounds/RoundDeleteButton";
 import { EmptyState } from "../../../../components/ui/EmptyState";
 import {
 	useCourses,
+	useReorderRounds,
 	useRoundsByTripId,
 	useTrip,
 } from "../../../../hooks/queries";
@@ -34,12 +37,27 @@ function formatDate(date: Date): string {
 function RoundsPage() {
 	const { tripId } = Route.useParams();
 	const { canManage } = useTripRole(tripId);
+	const [isEditMode, setIsEditMode] = useState(false);
 
 	const { data: trip } = useTrip(tripId);
 	const { data: rounds } = useRoundsByTripId(tripId);
 	const { data: courses } = useCourses();
+	const reorderRounds = useReorderRounds();
 
 	const courseMap = new Map((courses || []).map((c) => [c.id, c]));
+
+	function moveRound(index: number, direction: "up" | "down") {
+		if (!rounds) return;
+		const newIndex = direction === "up" ? index - 1 : index + 1;
+		if (newIndex < 0 || newIndex >= rounds.length) return;
+
+		const newOrder = [...rounds];
+		[newOrder[index], newOrder[newIndex]] = [newOrder[newIndex], newOrder[index]];
+		reorderRounds.mutate({
+			tripId,
+			roundIds: newOrder.map((r) => r.id),
+		});
+	}
 
 	if (!trip) {
 		return (
@@ -52,28 +70,78 @@ function RoundsPage() {
 	return (
 		<Container size="2" py="6">
 			<Flex direction="column" gap="5">
+				<Link to="/trips/$tripId" params={{ tripId }}>
+					<Button variant="ghost" size="1">
+						<ArrowLeft size={16} />
+						Back to Trip
+					</Button>
+				</Link>
 				<Flex justify="between" align="center">
 					<Flex direction="column" gap="3">
 						<Heading size="7">Rounds</Heading>
 						<Text color="gray">{trip.name}</Text>
 					</Flex>
-					{canManage && (
-						<Link to="/trips/$tripId/rounds/new" params={{ tripId }}>
-							<Button>
-								<Plus size={16} />
-								Add Round
+					<Flex gap="2">
+						{rounds && rounds.length > 1 && (
+							<Button
+								variant={isEditMode ? "solid" : "soft"}
+								color={isEditMode ? "amber" : "gray"}
+								onClick={() => setIsEditMode(!isEditMode)}
+							>
+								{isEditMode ? (
+									<>
+										<X size={16} />
+										Done
+									</>
+								) : (
+									<>
+										<Pencil size={16} />
+										Reorder
+									</>
+								)}
 							</Button>
-						</Link>
-					)}
+						)}
+						{canManage && (
+							<Link to="/trips/$tripId/rounds/new" params={{ tripId }}>
+								<Button>
+									<Plus size={16} />
+									Add Course
+								</Button>
+							</Link>
+						)}
+					</Flex>
 				</Flex>
 
 				{rounds && rounds.length > 0 ? (
 					<Flex direction="column" gap="2">
-						{rounds.map((round) => {
+						{rounds.map((round, index) => {
 							const course = courseMap.get(round.courseId);
 							return (
 								<Card key={round.id}>
 									<Flex justify="between" align="center">
+										{isEditMode && (
+											<Flex align="center" gap="2" pr="3">
+												<GripVertical size={16} style={{ color: "var(--gray-8)" }} />
+												<Flex direction="column" gap="1">
+													<IconButton
+														size="1"
+														variant="soft"
+														disabled={index === 0 || reorderRounds.isPending}
+														onClick={() => moveRound(index, "up")}
+													>
+														<ChevronUp size={14} />
+													</IconButton>
+													<IconButton
+														size="1"
+														variant="soft"
+														disabled={index === rounds.length - 1 || reorderRounds.isPending}
+														onClick={() => moveRound(index, "down")}
+													>
+														<ChevronDown size={14} />
+													</IconButton>
+												</Flex>
+											</Flex>
+										)}
 										<Link
 											to="/trips/$tripId/rounds/$roundId"
 											params={{ tripId, roundId: round.id }}
@@ -126,7 +194,7 @@ function RoundsPage() {
 								<Link to="/trips/$tripId/rounds/new" params={{ tripId }}>
 									<Button>
 										<Plus size={16} />
-										Add Round
+										Add Course
 									</Button>
 								</Link>
 							) : undefined

--- a/src/routes/trips/$tripId/teams.tsx
+++ b/src/routes/trips/$tripId/teams.tsx
@@ -10,8 +10,8 @@ import {
 	Text,
 	TextField,
 } from "@radix-ui/themes";
-import { createFileRoute } from "@tanstack/react-router";
-import { Plus, X } from "lucide-react";
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { ArrowLeft, Plus, X } from "lucide-react";
 import { EmptyState } from "../../../components/ui/EmptyState";
 import {
 	useCreateTeam,
@@ -146,6 +146,12 @@ function TeamsPage() {
 	return (
 		<Container size="2" py="6">
 			<Flex direction="column" gap="5">
+				<Link to="/trips/$tripId" params={{ tripId }}>
+					<Button variant="ghost" size="1">
+						<ArrowLeft size={16} />
+						Back to Trip
+					</Button>
+				</Link>
 				<Flex justify="between" align="center">
 					<Flex direction="column" gap="3">
 						<Heading size="7">Teams</Heading>

--- a/src/server/mutations/rounds.ts
+++ b/src/server/mutations/rounds.ts
@@ -61,3 +61,24 @@ export const deleteRound = createServerFn({ method: "POST" })
 			return { id };
 		});
 	});
+
+export const reorderRounds = createServerFn({ method: "POST" })
+	.inputValidator(
+		(data: { tripId: string; roundIds: string[] }) => data,
+	)
+	.handler(async ({ data: { tripId, roundIds } }): Promise<{ success: boolean }> => {
+		return wrapMutation("reorderRounds", async () => {
+			const sql = getDb();
+
+			// Update each round's roundNumber based on its position in the array
+			for (let i = 0; i < roundIds.length; i++) {
+				await sql`
+					UPDATE rounds
+					SET round_number = ${i + 1}
+					WHERE id = ${roundIds[i]} AND trip_id = ${tripId}
+				`;
+			}
+
+			return { success: true };
+		});
+	});

--- a/src/server/queries/rounds.ts
+++ b/src/server/queries/rounds.ts
@@ -30,7 +30,7 @@ export const getRoundsByTripId = createServerFn({ method: "GET" })
       SELECT id, trip_id, course_id, round_date, round_number, notes, included_in_scoring
       FROM rounds
       WHERE trip_id = ${tripId}
-      ORDER BY round_date ASC, round_number ASC
+      ORDER BY round_number ASC
     `;
 		return rows.map((row) => ({
 			id: row.id as string,


### PR DESCRIPTION
## Summary
- Added ability for organizers to manually reorder rounds within a trip
- Up/down arrow buttons appear next to each round card when there are 2+ rounds
- Rounds are now sorted by `roundNumber` instead of date, preserving manual order
- Useful when playing multiple courses per day or when rounds are played out of order

## Changes
- Added `reorderRounds` server mutation
- Added `useReorderRounds` hook
- Updated rounds query to sort by `roundNumber ASC` only
- Added reorder UI controls to rounds list page
- Also includes back button and "Add Course" label (overlaps with PR #23)

## Test plan
- [ ] Navigate to a trip with 2+ rounds
- [ ] As organizer, click up/down arrows to reorder rounds
- [ ] Verify round numbers update correctly
- [ ] Refresh page → order should be preserved
- [ ] Non-organizers should not see reorder controls

This pull request and its description were written by Isaac.